### PR TITLE
Clarify planned crates and document formats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Test
         run: make test
       - name: Lint Markdown
-        uses: DavidAnson/markdownlint-cli2-action@v20
+        uses: DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e # v20
         with:
           globs: '**/*.md'
       - name: Validate diagrams

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
       - name: Test
         run: make test
       - name: Lint Markdown
-        run: make markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@v20
+        with:
+          globs: '**/*.md'
       - name: Validate diagrams
         run: make nixie

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -35,8 +35,7 @@ core data structures of the engine.
   `get_pois_in_bbox(&self, bbox: &geo::Rect) -> Vec<PointOfInterest>`.
 - [ ] Define the `TravelTimeProvider` trait with an `async` method
   <!-- markdownlint-disable-next-line MD013 -->
-  `get_travel_time_matrix(&self, pois: &[PointOfInterest]) -> Result<Vec<Vec<Duration>>, Error>`
-  .
+  `get_travel_time_matrix(&self, pois: &[PointOfInterest]) -> Result<Vec<Vec<Duration>>, Error>`.
 - [ ] Define the `Scorer` trait with a
   `score(&self, poi: &PointOfInterest, profile: &InterestProfile) -> f32`
   method.
@@ -166,6 +165,13 @@ This phase ensures the engine is robust, reliable, and ready for integration.
   `solver-ortools`, and `store-sqlite`.
 - [ ] Forward feature flags from member crates using `[features]` and
   `dep:`-scoped features to ensure a single source of truth.
+
+  ```toml
+  [features]
+  solver-vrp = ["dep:wildside-solver-vrp"]
+  solver-ortools = ["dep:wildside-solver-ortools"]
+  ```
+
 - [ ] Use `#[cfg(feature = "...")]` attributes to conditionally compile the
   different solver and store implementations.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,7 +7,7 @@ core data structures of the engine.
 
 - **Set up Project Structure**
 
-- [x] Create the repository root directory `wildside-engine` and initialise a
+- [x] Create the repository root directory `wildside-engine` and initialize a
   virtual workspace:
 
   ```bash
@@ -35,7 +35,8 @@ core data structures of the engine.
   `get_pois_in_bbox(&self, bbox: &geo::Rect) -> Vec<PointOfInterest>`.
 - [ ] Define the `TravelTimeProvider` trait with an `async` method
   <!-- markdownlint-disable-next-line MD013 -->
-  `get_travel_time_matrix(&self, pois: &[PointOfInterest]) -> Result<Vec<Vec<Duration>>, Error>`.
+  `get_travel_time_matrix(&self, pois: &[PointOfInterest]) -> Result<Vec<Vec<Duration>>, Error>`
+  .
 - [ ] Define the `Scorer` trait with a
   `score(&self, poi: &PointOfInterest, profile: &InterestProfile) -> f32`
   method.
@@ -53,7 +54,7 @@ core data structures of the engine.
 
 - **Adopt GeoRust Primitives**
 
-- [ ] Standardise on `geo::Coord` for all location data within the
+- [ ] Standardize on `geo::Coord` for all location data within the
   `PointOfInterest` struct.
 - [ ] Create a function
   `build_spatial_index(pois: &[PointOfInterest]) -> rstar::RTree<PointOfInterest>`
@@ -80,7 +81,7 @@ core data structures of the engine.
   `ingest_osm_pbf`, then the Wikidata ETL process, and finally
   `build_spatial_index`, saving the resulting `pois.db` and `pois.rstar` files.
 
-## Phase 2: Scoring and Personalisation
+## Phase 2: Scoring and Personalization
 
 This phase implements the core logic that gives the engine its intelligence.
 
@@ -89,8 +90,8 @@ This phase implements the core logic that gives the engine its intelligence.
 - [ ] Create the `wildside-scorer` crate.
 - [ ] Implement an offline process that iterates through `pois.db`, calculates
   a popularity score for each POI based on its sitelink count and heritage
-  status, and normalises the scores.
-- [ ] Serialise the resulting `HashMap<PoiId, f32>` of scores to a compact
+  status, and normalizes the scores.
+- [ ] Serialize the resulting `HashMap<PoiId, f32>` of scores to a compact
   binary file (`popularity.bin`) using a library like `bincode`.
 
 - **Implement User Relevance Scorer**
@@ -125,7 +126,7 @@ This phase tackles the complex route-finding algorithm.
 - [ ] It will then fetch the travel time matrix for these candidates from the
   `TravelTimeProvider`.
 - [ ] It will configure the `vrp-core` problem and objective function to
-  maximise the total collected score within the given time budget.
+  maximize the total collected score within the given time budget.
 - [ ] Finally, it will run the `vrp-core` solver and transform the result into
   a `SolveResponse`.
 
@@ -140,7 +141,7 @@ This phase tackles the complex route-finding algorithm.
 
 - [ ] Add a `solve` command to `wildside-cli` that accepts a path to a
   JSON file.
-- [ ] The command will deserialise the JSON into a `SolveRequest`, instantiate
+- [ ] The command will deserialize the JSON into a `SolveRequest`, instantiate
   the necessary components (store, scorer, solver), call the solver, and print
   the resulting `SolveResponse` as formatted JSON.
 
@@ -163,14 +164,16 @@ This phase ensures the engine is robust, reliable, and ready for integration.
 
 - [ ] In the root `Cargo.toml`, define features like `solver-vrp`,
   `solver-ortools`, and `store-sqlite`.
+- [ ] Forward feature flags from member crates using `[features]` and
+  `dep:`-scoped features to ensure a single source of truth.
 - [ ] Use `#[cfg(feature = "...")]` attributes to conditionally compile the
   different solver and store implementations.
 
-- **Finalise Licensing and Versioning**
+- **Finalize Licensing and Versioning**
 
 - [ ] Add the ISC `LICENSE` file to the root of the workspace and to each
   crate's `Cargo.toml`.
-- [ ] Initialise a `CHANGELOG.md` file at the root, documenting the initial
+- [ ] Initialize a `CHANGELOG.md` file at the root, documenting the initial
   `0.1.0` feature set.
 
 - **(Optional) Implement OR-Tools Solver**

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -35,8 +35,8 @@ core data structures of the engine.
   `get_pois_in_bbox(&self, bbox: &geo::Rect) -> Vec<PointOfInterest>`.
 - [ ] Define the `TravelTimeProvider` trait with an `async` method
   <!-- markdownlint-disable-next-line MD013 -->
-  `get_travel_time_matrix(&self, pois: &[PointOfInterest]) -> Result<Vec<Vec<Duration>>, Error>`
-  .
+  `get_travel_time_matrix(&self, pois: &[PointOfInterest]) ->
+  Result<Vec<Vec<Duration>>, Error>.`
 - [ ] Define the `Scorer` trait with a
   `score(&self, poi: &PointOfInterest, profile: &InterestProfile) -> f32`
   method.
@@ -165,13 +165,20 @@ This phase ensures the engine is robust, reliable, and ready for integration.
 - [ ] In the root `Cargo.toml`, define features like `solver-vrp`,
   `solver-ortools`, and `store-sqlite`.
 - [ ] Forward feature flags from member crates using `[features]` and
-  `dep:`-scoped features to ensure a single source of truth.
+  `dep:`-scoped entries to ensure a single source of truth.
 
   ```toml
+  # In the root Cargo.toml
+  [dependencies]
+  wildside-solver-vrp = { version = "0.1", optional = true, default-features = false }
+  wildside-solver-ortools = { version = "0.1", optional = true, default-features = false }
+  wildside-data = { version = "0.1", optional = true, default-features = false }
+
   [features]
   solver-vrp = ["dep:wildside-solver-vrp"]
   solver-ortools = ["dep:wildside-solver-ortools"]
-  store-sqlite = ["dep:wildside-data?/sqlite"]
+  # Enable the optional dependency and forward its `sqlite` feature
+  store-sqlite = ["dep:wildside-data", "wildside-data/sqlite"]
   ```
 
 - [ ] Use `#[cfg(feature = "...")]` attributes to conditionally compile the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -35,7 +35,8 @@ core data structures of the engine.
   `get_pois_in_bbox(&self, bbox: &geo::Rect) -> Vec<PointOfInterest>`.
 - [ ] Define the `TravelTimeProvider` trait with an `async` method
   <!-- markdownlint-disable-next-line MD013 -->
-  `get_travel_time_matrix(&self, pois: &[PointOfInterest]) -> Result<Vec<Vec<Duration>>, Error>`.
+  `get_travel_time_matrix(&self, pois: &[PointOfInterest]) -> Result<Vec<Vec<Duration>>, Error>`
+  .
 - [ ] Define the `Scorer` trait with a
   `score(&self, poi: &PointOfInterest, profile: &InterestProfile) -> f32`
   method.
@@ -80,7 +81,7 @@ core data structures of the engine.
   `ingest_osm_pbf`, then the Wikidata ETL process, and finally
   `build_spatial_index`, saving the resulting `pois.db` and `pois.rstar` files.
 
-## Phase 2: Scoring and Personalization
+## Phase 2: Scoring and personalization
 
 This phase implements the core logic that gives the engine its intelligence.
 
@@ -170,6 +171,7 @@ This phase ensures the engine is robust, reliable, and ready for integration.
   [features]
   solver-vrp = ["dep:wildside-solver-vrp"]
   solver-ortools = ["dep:wildside-solver-ortools"]
+  store-sqlite = ["dep:wildside-data?/sqlite"]
   ```
 
 - [ ] Use `#[cfg(feature = "...")]` attributes to conditionally compile the

--- a/docs/wildside-engine-design.md
+++ b/docs/wildside-engine-design.md
@@ -355,7 +355,7 @@ for performance and scalability.
   - `popularity.bin`: A compact binary file of pre-calculated global
     popularity scores. The structure remains stable across releases.
 
-#### 3.4.1. Artefact Versioning and Migration
+#### 3.4.1. Artefact versioning and migration
 
 Embed a file-format version in each artefact header. Bump the version on
 incompatible changes and provide a migrator in `wildside-cli` to upgrade

--- a/docs/wildside-engine-design.md
+++ b/docs/wildside-engine-design.md
@@ -353,13 +353,16 @@ for performance and scalability.
     near-instant startup. The layout remains stable across 0.x releases.
 
   - `popularity.bin`: A compact binary file of pre-calculated global
-    popularity scores. The structure remains stable across releases.
+    popularity scores. The structure remains stable across 0.x releases; bump
+    the artefact header version per §3.4.1 when making breaking changes.
 
 #### 3.4.1. Artefact versioning and migration
 
-Embed a file-format version in each artefact header. Bump the version on
-incompatible changes and provide a migrator in `wildside-cli` to upgrade
-existing data.
+Embed a magic number and a version tuple in each artefact header (e.g., 4-byte
+magic "WSID", u16 major, u16 minor). Bump the major for incompatible changes;
+bump the minor for backward-compatible additions. Provide a
+`wildside-cli migrate` subcommand to upgrade older artefacts, and emit a clear
+error showing expected vs. found versions on mismatch.
 
 - **Online Path:** The core engine library, when used by the web app, interacts
   *only* with these read-only artefacts. This design choice means the engine

--- a/docs/wildside-engine-design.md
+++ b/docs/wildside-engine-design.md
@@ -358,11 +358,12 @@ for performance and scalability.
 
 #### 3.4.1. Artefact versioning and migration
 
-Embed a magic number and a version tuple in each artefact header (e.g., 4-byte
-magic "WSID", u16 major, u16 minor). Bump the major for incompatible changes;
-bump the minor for backward-compatible additions. Provide a
-`wildside-cli migrate` subcommand to upgrade older artefacts, and emit a clear
-error showing expected vs. found versions on mismatch.
+Embed a fixed header: 4-byte ASCII magic "WSID", u16 major, u16 minor, u8
+flags, all little-endian. Bump MAJOR for incompatible changes; bump MINOR for
+backward-compatible additions. Readers MUST refuse unknown MAJOR versions and
+MAY accept newer MINOR versions. Provide a `wildside-cli migrate` subcommand
+that detects legacy headers, runs the appropriate migrator, and emits a clear
+error with expected vs found MAJOR.MINOR on mismatch.
 
 - **Online Path:** The core engine library, when used by the web app, interacts
   *only* with these read-only artefacts. This design choice means the engine

--- a/docs/wildside-engine-design.md
+++ b/docs/wildside-engine-design.md
@@ -37,7 +37,7 @@ system: building a robust, efficient, and scalable data ingestion pipeline for
 the OpenStreetMap (OSM) and Wikidata datasets. The architectural and library
 choices made here will fundamentally impact the performance, operational cost,
 and development complexity of the entire application. The goal is to transform
-raw, community-driven data into a set of structured, read-only artifacts that
+raw, community-driven data into a set of structured, read-only artefacts that
 can be efficiently queried by the core engine.
 
 ### 1.1. Processing Geospatial Structure: A Comparative Analysis of OpenStreetMap PBF Parsers
@@ -171,7 +171,7 @@ in-memory spatial index of POIs for fast and efficient candidate selection.
 This section translates the abstract scoring formula,
 Score(POI)=wp​⋅P(POI)+wu​⋅U(POI,user_profile), into a concrete implementation
 plan. This logic will be encapsulated within a dedicated `Scorer` component,
-leveraging the data artifacts produced by the pipeline in Section 1.
+leveraging the data artefacts produced by the pipeline in Section 1.
 
 ### 2.1. Calculating Global Popularity `P(POI)`
 
@@ -200,7 +200,7 @@ The implementation steps within the ETL pipeline are as follows:
 
 3. These individual metrics are then normalized and combined using a weighted
    formula to produce a single floating-point `global_popularity_score`, which
-   is then saved to the `popularity.bin` artifact.
+   is then saved to the `popularity.bin` artefact.
 
 ### 2.2. Calculating User Relevance `U(POI, user_profile)`
 
@@ -226,7 +226,7 @@ The implementation steps at request time are as follows:
    the pre-computed `P(POI)` (loaded from `popularity.bin`) and the
    just-in-time `U(POI)` using the specified weights: wp​ and wu​.
 
-The architectural decision to use offline, read-only data artifacts is the key
+The architectural decision to use offline, read-only data artefacts is the key
 technical enabler for this entire personalization feature. Performing thousands
 of property checks as indexed queries against a local database can be
 accomplished in milliseconds, ensuring a responsive user experience.
@@ -276,32 +276,33 @@ clear boundaries while allowing for atomic changes across crates when necessary.
   - Implements the `PoiStore` trait from the core crate.
 
   - Handles OSM PBF ingestion (using `osmpbf`), Wikidata dump parsing, and
-    building the data artifacts (e.g., SQLite/RocksDB stores and the `rstar`
+    building the data artefacts (e.g., SQLite/RocksDB stores and the `rstar`
     index).
 
-- `wildside-scorer`: Implements the `Scorer` trait.
+- (Planned) `wildside-scorer`: Implements the `Scorer` trait.
 
   - Contains the logic for both the offline pre-computation of global
     popularity scores and the per-request calculation of user relevance.
 
-- `wildside-solver-vrp`: The default, native Rust implementation of the
-  `Solver` trait, using the `vrp-core` library.
+- (Planned) `wildside-solver-vrp`: The default, native Rust implementation of
+  the `Solver` trait, using the `vrp-core` library.
 
-- `wildside-solver-ortools`: An optional implementation of the `Solver`
-  trait, using bindings to Google's CP-SAT solver. This would be enabled via a
-  feature flag for users who require its specific performance characteristics
-  and are willing to manage the C++ dependency.
+- (Planned) `wildside-solver-ortools`: An optional implementation of the
+  `Solver` trait, using bindings to Google's CP-SAT solver. This would be
+  enabled via a feature flag for users who require its specific performance
+  characteristics and are willing to manage the C++ dependency.
 
 - `wildside-cli`: A small command-line application for operational tasks.
 
   - `ingest`: Runs the full ETL pipeline from `wildside-data` to build
-    the necessary data artifacts.
+    the necessary data artefacts.
 
-  - `score`: Triggers the batch computation of global popularity scores.
+  - (Planned) `score`: Triggers the batch computation of global popularity
+    scores.
 
-  - `solve`: A utility to run the solver from the command line by feeding it a
-    JSON request, which is invaluable for performance testing and offline
-    debugging.
+  - (Planned) `solve`: A utility to run the solver from the command line by
+    feeding it a JSON request, which is invaluable for performance testing and
+    offline debugging.
 
 ### 3.3. A Stable, Performant, and Boring API Surface
 
@@ -341,20 +342,24 @@ for performance and scalability.
 
 - **Offline Path:** The `wildside-cli` is used to execute the idempotent
   ETL process. This process takes raw OSM and Wikidata data and produces a set
-  of optimized, read-only artifacts:
+  of optimized, read-only artefacts:
 
   - `pois.db`: An SQLite (or RocksDB) file containing the enriched POI data,
-    indexed for fast lookups.
+    indexed for fast lookups. Schema changes are backward compatible within a
+    major release.
 
   - `pois.rstar`: A serialized R\*-tree file for fast spatial queries, which
     can be loaded into memory using memory-mapping (e.g., with `memmap2`) for
-    near-instant startup.
+    near-instant startup. The layout remains stable across 0.x releases.
 
-  - `popularity.bin`: A compact binary file of pre-calculated global popularity
-    scores.
+  - `popularity.bin`: A compact binary file of pre-calculated global
+    popularity scores. The structure remains stable across releases.
+
+  - Embed a file-format version in each artefact header; bump on incompatible
+    changes and provide a migrator in `wildside-cli`.
 
 - **Online Path:** The core engine library, when used by the web app, interacts
-  *only* with these read-only artifacts. This design choice means the engine
+  *only* with these read-only artefacts. This design choice means the engine
   itself is side-effect free during a request. It allows application instances
   to be scaled horizontally without needing complex shared state or writeable
   database connections, dramatically simplifying deployment and improving

--- a/docs/wildside-engine-design.md
+++ b/docs/wildside-engine-design.md
@@ -355,8 +355,11 @@ for performance and scalability.
   - `popularity.bin`: A compact binary file of pre-calculated global
     popularity scores. The structure remains stable across releases.
 
-  - Embed a file-format version in each artefact header; bump on incompatible
-    changes and provide a migrator in `wildside-cli`.
+#### 3.4.1. Artefact Versioning and Migration
+
+Embed a file-format version in each artefact header. Bump the version on
+incompatible changes and provide a migrator in `wildside-cli` to upgrade
+existing data.
 
 - **Online Path:** The core engine library, when used by the web app, interacts
   *only* with these read-only artefacts. This design choice means the engine


### PR DESCRIPTION
## Summary
- Flag scorer and solver crates and CLI subcommands as planned
- Document data artefact formats with versioning guidance
- Standardize roadmap spelling and forward feature flags from member crates
- Replace markdownlint script in CI with markdownlint-cli2 action

## Testing
- ✅ `make fmt`
- ✅ `make markdownlint`
- ✅ `make nixie`
- ✅ `RUSTC_WRAPPER= make lint`
- ✅ `RUSTC_WRAPPER= make test`


------
https://chatgpt.com/codex/tasks/task_e_68a3664c91dc8322bdb068f6e049cc20

## Summary by Sourcery

Clarify planned crates and CLI subcommands, standardize terminology and spelling across docs, document artefact file formats with versioning guidance, forward workspace feature flags, and replace the markdownlint script with the markdownlint-cli2 GitHub Action in CI

New Features:
- Document file-format version embedding and migrator guidance for data artefacts

Enhancements:
- Mark wildside-scorer, wildside-solver-vrp, wildside-solver-ortools and corresponding CLI subcommands as planned
- Standardize ‘artefact’ terminology and unify spelling in design and roadmap documentation
- Forward feature flags from member crates to the root workspace

CI:
- Replace the markdownlint make target with the DavidAnson/markdownlint-cli2 GitHub Action

Documentation:
- Update wildside-engine-design and roadmap.md to reflect spelling changes and versioning notes