### PR TITLE
Install uv for Nixie validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,15 @@ jobs:
         run: make test
       - name: Lint Markdown
         run: make markdownlint
+      - name: Install uv
+        # v6.4.3
+        uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc
+        with:
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+            **/scripts/*.py
+      - name: Install Nixie
+        run: uv tool install --from git+https://github.com/leynos/nixie nixie
       - name: Validate diagrams
         run: make nixie


### PR DESCRIPTION
## Summary
- install `uv` in the CI workflow
- install `nixie` via `uv` before validating diagrams

## Testing
- `make fmt`
- `RUSTC_WRAPPER= make lint`
- `RUSTC_WRAPPER= make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_68a3782039c08322b10d2eebe8efd8e1

## Summary by Sourcery

Add UV installation to the CI workflow and use it to install Nixie before validating diagrams

CI:
- Add GitHub Action step to install uv
- Add CI step to install Nixie via uv before diagram validation