### PR TITLE
Add PoiStore trait with bounding box query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "rstest-bdd"
 version = "0.1.0"
-source = "git+https://github.com/leynos/rstest-bdd?tag=v0.1.0-alpha1#2cc6150aa8c3c17175154b98f88bea2b054af4ce"
+source = "git+https://github.com/leynos/rstest-bdd?rev=2cc6150aa8c3c17175154b98f88bea2b054af4ce#2cc6150aa8c3c17175154b98f88bea2b054af4ce"
 dependencies = [
  "gherkin",
  "hashbrown",
@@ -515,7 +515,7 @@ dependencies = [
 [[package]]
 name = "rstest-bdd-macros"
 version = "0.1.0"
-source = "git+https://github.com/leynos/rstest-bdd?tag=v0.1.0-alpha1#2cc6150aa8c3c17175154b98f88bea2b054af4ce"
+source = "git+https://github.com/leynos/rstest-bdd?rev=2cc6150aa8c3c17175154b98f88bea2b054af4ce#2cc6150aa8c3c17175154b98f88bea2b054af4ce"
 dependencies = [
  "gherkin",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "gherkin"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20b79820c0df536d1f3a089a2fa958f61cb96ce9e0f3f8f507f5a31179567755"
+dependencies = [
+ "heck",
+ "peg",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+ "textwrap",
+ "thiserror",
+ "typed-builder",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +238,12 @@ dependencies = [
  "hash32",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "i_float"
@@ -277,6 +300,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inventory"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,6 +350,33 @@ dependencies = [
  "autocfg",
  "libm",
 ]
+
+[[package]]
+name = "peg"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f76678828272f177ac33b7e2ac2e3e73cc6c1cd1e3e387928aa69562fa51367"
+dependencies = [
+ "peg-macros",
+ "peg-runtime",
+]
+
+[[package]]
+name = "peg-macros"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "636d60acf97633e48d266d7415a9355d4389cea327a193f87df395d88cd2b14d"
+dependencies = [
+ "peg-runtime",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "peg-runtime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9555b1514d2d99d78150d3c799d4c357a3e2c2a8062cd108e93a06d9057629c5"
 
 [[package]]
 name = "pin-project-lite"
@@ -442,6 +501,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest-bdd"
+version = "0.1.0"
+source = "git+https://github.com/leynos/rstest-bdd?tag=v0.1.0-alpha1#2cc6150aa8c3c17175154b98f88bea2b054af4ce"
+dependencies = [
+ "gherkin",
+ "hashbrown",
+ "inventory",
+ "regex",
+ "thiserror",
+]
+
+[[package]]
+name = "rstest-bdd-macros"
+version = "0.1.0"
+source = "git+https://github.com/leynos/rstest-bdd?tag=v0.1.0-alpha1#2cc6150aa8c3c17175154b98f88bea2b054af4ce"
+dependencies = [
+ "gherkin",
+ "proc-macro2",
+ "quote",
+ "rstest-bdd",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
 name = "rstest_macros"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,10 +553,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "semver"
@@ -525,6 +624,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "spade"
 version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +656,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
 ]
 
 [[package]]
@@ -591,10 +707,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-builder"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe83c85a85875e8c4cb9ce4a890f05b23d38cd0d47647db7895d3d2a79566d2"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a3151c41d0b13e3d011f98adc24434560ef06673a155a6c7f66b9879eecce2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wildside-cli"
@@ -606,6 +764,8 @@ version = "0.1.0"
 dependencies = [
  "geo",
  "rstest",
+ "rstest-bdd",
+ "rstest-bdd-macros",
  "serde",
  "serde_json",
  "thiserror",
@@ -614,6 +774,95 @@ dependencies = [
 [[package]]
 name = "wildside-data"
 version = "0.1.0"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "rstest-bdd"
 version = "0.1.0"
-source = "git+https://github.com/leynos/rstest-bdd?rev=2cc6150aa8c3c17175154b98f88bea2b054af4ce#2cc6150aa8c3c17175154b98f88bea2b054af4ce"
+source = "git+https://github.com/leynos/rstest-bdd?tag=v0.1.0-alpha1#2cc6150aa8c3c17175154b98f88bea2b054af4ce"
 dependencies = [
  "gherkin",
  "hashbrown",
@@ -515,7 +515,7 @@ dependencies = [
 [[package]]
 name = "rstest-bdd-macros"
 version = "0.1.0"
-source = "git+https://github.com/leynos/rstest-bdd?rev=2cc6150aa8c3c17175154b98f88bea2b054af4ce#2cc6150aa8c3c17175154b98f88bea2b054af4ce"
+source = "git+https://github.com/leynos/rstest-bdd?tag=v0.1.0-alpha1#2cc6150aa8c3c17175154b98f88bea2b054af4ce"
 dependencies = [
  "gherkin",
  "proc-macro2",

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -31,12 +31,14 @@ core data structures of the engine.
   and their corresponding weights.
 - [x] Define the `Route` struct, containing an ordered `Vec<PointOfInterest>`
   and a `total_duration: std::time::Duration`.
-- [x] Define the `PoiStore` trait with methods like
-  `get_pois_in_bbox(&self, bbox: &Rect<f64>) -> Box<dyn Iterator<Item = PointOfInterest>>>`.
+- [x] Define the `PoiStore` trait with methods like:
+  <!-- markdownlint-disable-next-line MD013 -->
+  `get_pois_in_bbox(&self, bbox: &Rect<f64>) -> Box<dyn Iterator<Item =
+  PointOfInterest>>>`
 - [ ] Define the `TravelTimeProvider` trait with an `async` method
   <!-- markdownlint-disable-next-line MD013 -->
-  `get_travel_time_matrix(&self, pois: &[PointOfInterest]) -> Result<Vec<Vec<Duration>>, Error>`
-  .
+  `get_travel_time_matrix(&self, pois: &[PointOfInterest]) ->
+  Result<Vec<Vec<Duration>>, Error>`
 - [ ] Define the `Scorer` trait with a
   `score(&self, poi: &PointOfInterest, profile: &InterestProfile) -> f32`
   method.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -31,11 +31,12 @@ core data structures of the engine.
   and their corresponding weights.
 - [x] Define the `Route` struct, containing an ordered `Vec<PointOfInterest>`
   and a `total_duration: std::time::Duration`.
-- [ ] Define the `PoiStore` trait with methods like
+- [x] Define the `PoiStore` trait with methods like
   `get_pois_in_bbox(&self, bbox: &geo::Rect) -> Vec<PointOfInterest>`.
 - [ ] Define the `TravelTimeProvider` trait with an `async` method
   <!-- markdownlint-disable-next-line MD013 -->
-  `get_travel_time_matrix(&self, pois: &[PointOfInterest]) -> Result<Vec<Vec<Duration>>, Error>`.
+  `get_travel_time_matrix(&self, pois: &[PointOfInterest]) -> Result<Vec<Vec<Duration>>, Error>`
+  .
 - [ ] Define the `Scorer` trait with a
   `score(&self, poi: &PointOfInterest, profile: &InterestProfile) -> f32`
   method.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -32,7 +32,7 @@ core data structures of the engine.
 - [x] Define the `Route` struct, containing an ordered `Vec<PointOfInterest>`
   and a `total_duration: std::time::Duration`.
 - [x] Define the `PoiStore` trait with methods like
-  `get_pois_in_bbox(&self, bbox: &geo::Rect) -> Box<dyn Iterator<Item = PointOfInterest>>>`.
+  `get_pois_in_bbox(&self, bbox: &Rect<f64>) -> Box<dyn Iterator<Item = PointOfInterest>>>`.
 - [ ] Define the `TravelTimeProvider` trait with an `async` method
   <!-- markdownlint-disable-next-line MD013 -->
   `get_travel_time_matrix(&self, pois: &[PointOfInterest]) -> Result<Vec<Vec<Duration>>, Error>`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -33,8 +33,8 @@ core data structures of the engine.
   and a `total_duration: std::time::Duration`.
 - [x] Define the `PoiStore` trait with methods like:
   <!-- markdownlint-disable-next-line MD013 -->
-  `get_pois_in_bbox(&self, bbox: &Rect<f64>) -> Box<dyn Iterator<Item =
-  PointOfInterest> + Send>`
+  `get_pois_in_bbox(&self, bbox: &geo::Rect<f64>) -> Box<dyn Iterator<Item =
+  PointOfInterest> + Send + '_>`
 - [ ] Define the `TravelTimeProvider` trait with a method
   <!-- markdownlint-disable-next-line MD013 -->
   `get_travel_time_matrix(&self, pois: &[PointOfInterest]) ->

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,8 +34,8 @@ core data structures of the engine.
 - [x] Define the `PoiStore` trait with methods like:
   <!-- markdownlint-disable-next-line MD013 -->
   `get_pois_in_bbox(&self, bbox: &Rect<f64>) -> Box<dyn Iterator<Item =
-  PointOfInterest>>>`
-- [ ] Define the `TravelTimeProvider` trait with an `async` method
+  PointOfInterest> + Send>`
+- [ ] Define the `TravelTimeProvider` trait with a method
   <!-- markdownlint-disable-next-line MD013 -->
   `get_travel_time_matrix(&self, pois: &[PointOfInterest]) ->
   Result<Vec<Vec<Duration>>, Error>`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -32,7 +32,7 @@ core data structures of the engine.
 - [x] Define the `Route` struct, containing an ordered `Vec<PointOfInterest>`
   and a `total_duration: std::time::Duration`.
 - [x] Define the `PoiStore` trait with methods like
-  `get_pois_in_bbox(&self, bbox: &geo::Rect) -> Vec<PointOfInterest>`.
+  `get_pois_in_bbox(&self, bbox: &geo::Rect) -> Box<dyn Iterator<Item = PointOfInterest>>>`.
 - [ ] Define the `TravelTimeProvider` trait with an `async` method
   <!-- markdownlint-disable-next-line MD013 -->
   `get_travel_time_matrix(&self, pois: &[PointOfInterest]) -> Result<Vec<Vec<Duration>>, Error>`

--- a/docs/wildside-engine-design.md
+++ b/docs/wildside-engine-design.md
@@ -47,6 +47,10 @@ providing a stable vocabulary across crates.
 - `Route` contains the ordered list of `PointOfInterest` values selected for a
   tour and the overall `Duration` required to visit them. `Route::new` and
   `Route::empty` offer clear constructors.
+- `PoiStore` abstracts read-only POI access. The
+  `get_pois_in_bbox(&self, bbox: &geo::Rect<f64>) -> Vec<PointOfInterest>`
+  method returns all POIs inside a bounding box, leaving indexing strategies to
+  implementors.
 
 These definitions form the backbone of the recommendation engine; higher level
 components such as scorers and solvers operate exclusively on these types.

--- a/docs/wildside-engine-design.md
+++ b/docs/wildside-engine-design.md
@@ -48,9 +48,9 @@ providing a stable vocabulary across crates.
   tour and the overall `Duration` required to visit them. `Route::new` and
   `Route::empty` offer clear constructors.
 - `PoiStore` abstracts read-only POI access. The
-  `get_pois_in_bbox(&self, bbox: &geo::Rect<f64>) -> Vec<PointOfInterest>`
-  method returns all POIs inside a bounding box, leaving indexing strategies to
-  implementors.
+  `get_pois_in_bbox(&self, bbox: &geo::Rect<f64>) -> Box<dyn Iterator<Item = PointOfInterest>>>`
+  method yields POIs lazily inside a bounding box, leaving indexing strategies
+  to implementors and avoiding unnecessary allocation.
 
 These definitions form the backbone of the recommendation engine; higher level
 components such as scorers and solvers operate exclusively on these types.

--- a/docs/wildside-engine-design.md
+++ b/docs/wildside-engine-design.md
@@ -47,13 +47,13 @@ providing a stable vocabulary across crates.
 - `Route` contains the ordered list of `PointOfInterest` values selected for a
   tour and the overall `Duration` required to visit them. `Route::new` and
   `Route::empty` offer clear constructors.
-- `PoiStore` abstracts read-only POI access. The
-  `get_pois_in_bbox(&self, bbox: &Rect<f64>) -> Box<dyn Iterator<Item =`
-  `PointOfInterest> + Send>` method returns all POIs inside an axis-aligned
-  bounding box (WGS84; `x = longitude`, `y = latitude`). The full semantics are
-  documented in
-  [`wildside_core::store::PoiStore`](../wildside-core/src/store.rs); indexing
-  strategy is left to implementers.
+  - `PoiStore` abstracts read-only POI access. The
+    `get_pois_in_bbox(&self, bbox: &geo::Rect<f64>) -> Box<dyn Iterator<Item =`
+    `PointOfInterest> + Send + '_>` method returns all POIs inside an
+    axis-aligned bounding box (WGS84; `x = longitude`, `y = latitude`). The
+    full semantics are documented in
+    [`wildside_core::store::PoiStore`](../wildside-core/src/store.rs); indexing
+    strategy is left to implementers.
 
 These definitions form the backbone of the recommendation engine; higher level
 components such as scorers and solvers operate exclusively on these types.

--- a/docs/wildside-engine-design.md
+++ b/docs/wildside-engine-design.md
@@ -48,9 +48,10 @@ providing a stable vocabulary across crates.
   tour and the overall `Duration` required to visit them. `Route::new` and
   `Route::empty` offer clear constructors.
 - `PoiStore` abstracts read-only POI access. The
-  `get_pois_in_bbox(&self, bbox: &Rect<f64>) -> Box<dyn Iterator<Item = PointOfInterest>>>`
-  method returns all POIs inside an axis-aligned bounding box (WGS84;
-  `x = longitude`, `y = latitude`). The full semantics are documented in
+  `get_pois_in_bbox(&self, bbox: &Rect<f64>) -> Box<dyn Iterator<Item =`
+  `PointOfInterest> + Send>` method returns all POIs inside an axis-aligned
+  bounding box (WGS84; `x = longitude`, `y = latitude`). The full semantics are
+  documented in
   [`wildside_core::store::PoiStore`](../wildside-core/src/store.rs); indexing
   strategy is left to implementers.
 

--- a/docs/wildside-engine-design.md
+++ b/docs/wildside-engine-design.md
@@ -48,9 +48,11 @@ providing a stable vocabulary across crates.
   tour and the overall `Duration` required to visit them. `Route::new` and
   `Route::empty` offer clear constructors.
 - `PoiStore` abstracts read-only POI access. The
-  `get_pois_in_bbox(&self, bbox: &geo::Rect<f64>) -> Box<dyn Iterator<Item = PointOfInterest>>>`
-  method yields POIs lazily inside a bounding box, leaving indexing strategies
-  to implementors and avoiding unnecessary allocation.
+  `get_pois_in_bbox(&self, bbox: &Rect<f64>) -> Box<dyn Iterator<Item = PointOfInterest>>>`
+  method returns all POIs inside an axis-aligned bounding box (WGS84;
+  `x = longitude`, `y = latitude`). The full semantics are documented in
+  [`wildside_core::store::PoiStore`](../wildside-core/src/store.rs); indexing
+  strategy is left to implementers.
 
 These definitions form the backbone of the recommendation engine; higher level
 components such as scorers and solvers operate exclusively on these types.

--- a/docs/wildside-engine-design.md
+++ b/docs/wildside-engine-design.md
@@ -47,13 +47,14 @@ providing a stable vocabulary across crates.
 - `Route` contains the ordered list of `PointOfInterest` values selected for a
   tour and the overall `Duration` required to visit them. `Route::new` and
   `Route::empty` offer clear constructors.
-  - `PoiStore` abstracts read-only POI access. The
-    `get_pois_in_bbox(&self, bbox: &geo::Rect<f64>) -> Box<dyn Iterator<Item =`
-    `PointOfInterest> + Send + '_>` method returns all POIs inside an
-    axis-aligned bounding box (WGS84; `x = longitude`, `y = latitude`). The
-    full semantics are documented in
-    [`wildside_core::store::PoiStore`](../wildside-core/src/store.rs); indexing
-    strategy is left to implementers.
+<!-- markdownlint-disable line-length -->
+- `PoiStore` abstracts read-only POI access. The
+  `get_pois_in_bbox(&self, bbox: &geo::Rect<f64>) -> Box<dyn Iterator<Item = PointOfInterest> + Send + '_>`
+   method returns all POIs inside an axis-aligned bounding box (WGS84;
+  `x = longitude`, `y = latitude`). The full semantics are documented in
+  [`wildside_core::store::PoiStore`](../wildside-core/src/store.rs); indexing
+  strategy is left to implementers.
+<!-- markdownlint-enable line-length -->
 
 These definitions form the backbone of the recommendation engine; higher level
 components such as scorers and solvers operate exclusively on these types.

--- a/wildside-core/Cargo.toml
+++ b/wildside-core/Cargo.toml
@@ -11,6 +11,8 @@ serde = { version = "1", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 rstest = "0.26.1"
+rstest-bdd = { git = "https://github.com/leynos/rstest-bdd", tag = "v0.1.0-alpha1" }
+rstest-bdd-macros = { git = "https://github.com/leynos/rstest-bdd", tag = "v0.1.0-alpha1" }
 serde_json = "1"
 
 [features]

--- a/wildside-core/Cargo.toml
+++ b/wildside-core/Cargo.toml
@@ -18,3 +18,4 @@ serde_json = "1"
 [features]
 default = []
 serde = ["dep:serde"]
+test-utils = []

--- a/wildside-core/Cargo.toml
+++ b/wildside-core/Cargo.toml
@@ -11,8 +11,8 @@ serde = { version = "1", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 rstest = "0.26.1"
-rstest-bdd = { git = "https://github.com/leynos/rstest-bdd", rev = "2cc6150aa8c3c17175154b98f88bea2b054af4ce" }
-rstest-bdd-macros = { git = "https://github.com/leynos/rstest-bdd", rev = "2cc6150aa8c3c17175154b98f88bea2b054af4ce" }
+rstest-bdd = { git = "https://github.com/leynos/rstest-bdd", tag = "v0.1.0-alpha1", package = "rstest-bdd" }
+rstest-bdd-macros = { git = "https://github.com/leynos/rstest-bdd", tag = "v0.1.0-alpha1", package = "rstest-bdd-macros" }
 serde_json = "1"
 
 [features]

--- a/wildside-core/Cargo.toml
+++ b/wildside-core/Cargo.toml
@@ -11,8 +11,8 @@ serde = { version = "1", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 rstest = "0.26.1"
-rstest-bdd = { git = "https://github.com/leynos/rstest-bdd", tag = "v0.1.0-alpha1" }
-rstest-bdd-macros = { git = "https://github.com/leynos/rstest-bdd", tag = "v0.1.0-alpha1" }
+rstest-bdd = { git = "https://github.com/leynos/rstest-bdd", rev = "2cc6150aa8c3c17175154b98f88bea2b054af4ce" }
+rstest-bdd-macros = { git = "https://github.com/leynos/rstest-bdd", rev = "2cc6150aa8c3c17175154b98f88bea2b054af4ce" }
 serde_json = "1"
 
 [features]

--- a/wildside-core/src/lib.rs
+++ b/wildside-core/src/lib.rs
@@ -3,9 +3,11 @@
 pub mod poi;
 pub mod profile;
 pub mod route;
+pub mod store;
 pub mod theme;
 
 pub use poi::PointOfInterest;
 pub use profile::InterestProfile;
 pub use route::Route;
+pub use store::PoiStore;
 pub use theme::Theme;

--- a/wildside-core/src/lib.rs
+++ b/wildside-core/src/lib.rs
@@ -11,3 +11,6 @@ pub use profile::InterestProfile;
 pub use route::Route;
 pub use store::PoiStore;
 pub use theme::Theme;
+
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_support;

--- a/wildside-core/src/store.rs
+++ b/wildside-core/src/store.rs
@@ -10,7 +10,7 @@ use crate::PointOfInterest;
 
 /// Read-only access to persisted points of interest.
 ///
-/// Implementors are expected to store POIs in a spatial index such as an
+/// Implementers are expected to store POIs in a spatial index such as an
 /// R\*-tree. The bounding box uses WGS84 coordinates (`x = longitude`,
 /// `y = latitude`).
 ///
@@ -28,7 +28,7 @@ use crate::PointOfInterest;
 ///     fn get_pois_in_bbox(
 ///         &self,
 ///         bbox: &Rect<f64>,
-///     ) -> Box<dyn Iterator<Item = PointOfInterest> + '_> {
+///     ) -> Box<dyn Iterator<Item = PointOfInterest> + Send + '_> {
 ///         Box::new(
 ///             self.pois
 ///                 .iter()
@@ -63,7 +63,7 @@ pub trait PoiStore {
     ///   regions, not planar rectangles. Implementations MUST use great-circle
     ///   predicates for containment/intersection.
     ///
-    /// Implementors MAY internally:
+    /// Implementers MAY internally:
     /// - Split dateline-crossing boxes into two ranges, OR
     /// - Use a spherical index (e.g., S2/H3) to compute a covering, then
     ///   refine.
@@ -74,7 +74,10 @@ pub trait PoiStore {
     /// - `Region::polar_cap(min_lat: f64)`
     ///
     /// All POI filters MUST respect these semantics.
-    fn get_pois_in_bbox(&self, bbox: &Rect<f64>) -> Box<dyn Iterator<Item = PointOfInterest> + '_>;
+    fn get_pois_in_bbox(
+        &self,
+        bbox: &Rect<f64>,
+    ) -> Box<dyn Iterator<Item = PointOfInterest> + Send + '_>;
 }
 
 #[cfg(test)]

--- a/wildside-core/src/store.rs
+++ b/wildside-core/src/store.rs
@@ -1,0 +1,84 @@
+//! Data access traits for points of interest.
+//!
+//! The `PoiStore` trait defines a read-only interface for retrieving
+//! [`PointOfInterest`] values. Consumers can use it to query a set of POIs
+//! within a geographic bounding box.
+
+use geo::Rect;
+
+use crate::PointOfInterest;
+
+/// Read-only access to persisted points of interest.
+///
+/// Implementors are expected to store POIs in a spatial index such as an
+/// R\*-tree. The bounding box uses WGS84 coordinates (`x = longitude`,
+/// `y = latitude`).
+///
+/// # Examples
+///
+/// ```
+/// use geo::{Coord, Rect, Contains};
+/// use wildside_core::{PointOfInterest, PoiStore};
+///
+/// struct MemoryStore {
+///     pois: Vec<PointOfInterest>,
+/// }
+///
+/// impl PoiStore for MemoryStore {
+///     fn get_pois_in_bbox(&self, bbox: &Rect<f64>) -> Vec<PointOfInterest> {
+///         self.pois
+///             .iter()
+///             .filter(|p| bbox.contains(&p.location))
+///             .cloned()
+///             .collect()
+///     }
+/// }
+///
+/// let poi = PointOfInterest::with_empty_tags(1, Coord { x: 0.0, y: 0.0 });
+/// let store = MemoryStore { pois: vec![poi.clone()] };
+/// let bbox = Rect::new(Coord { x: -1.0, y: -1.0 }, Coord { x: 1.0, y: 1.0 });
+///
+/// assert_eq!(store.get_pois_in_bbox(&bbox), vec![poi]);
+/// ```
+pub trait PoiStore {
+    /// Return all POIs that fall within the provided bounding box.
+    fn get_pois_in_bbox(&self, bbox: &Rect<f64>) -> Vec<PointOfInterest>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use geo::{Contains, Coord};
+    use rstest::rstest;
+
+    struct MemoryStore {
+        pois: Vec<PointOfInterest>,
+    }
+
+    impl PoiStore for MemoryStore {
+        fn get_pois_in_bbox(&self, bbox: &Rect<f64>) -> Vec<PointOfInterest> {
+            self.pois
+                .iter()
+                .filter(|p| bbox.contains(&p.location))
+                .cloned()
+                .collect()
+        }
+    }
+
+    #[rstest]
+    fn returns_pois_inside_bbox() {
+        let poi = PointOfInterest::with_empty_tags(1, Coord { x: 0.0, y: 0.0 });
+        let store = MemoryStore {
+            pois: vec![poi.clone()],
+        };
+        let bbox = Rect::new(Coord { x: -1.0, y: -1.0 }, Coord { x: 1.0, y: 1.0 });
+        assert_eq!(store.get_pois_in_bbox(&bbox), vec![poi]);
+    }
+
+    #[rstest]
+    fn returns_empty_when_no_pois() {
+        let store = MemoryStore { pois: vec![] };
+        let bbox = Rect::new(Coord { x: -1.0, y: -1.0 }, Coord { x: 1.0, y: 1.0 });
+        assert!(store.get_pois_in_bbox(&bbox).is_empty());
+    }
+}

--- a/wildside-core/src/test_support.rs
+++ b/wildside-core/src/test_support.rs
@@ -1,0 +1,30 @@
+use geo::{Contains, Rect};
+
+use crate::{PoiStore, PointOfInterest};
+
+/// In-memory `PoiStore` implementation used in tests.
+///
+/// The store performs a linear scan and is intended only for small datasets.
+#[derive(Default)]
+pub struct MemoryStore {
+    pub pois: Vec<PointOfInterest>,
+}
+
+impl MemoryStore {
+    /// Create a store containing a single point of interest.
+    pub fn with_poi(poi: PointOfInterest) -> Self {
+        Self { pois: vec![poi] }
+    }
+}
+
+impl PoiStore for MemoryStore {
+    fn get_pois_in_bbox(&self, bbox: &Rect<f64>) -> Box<dyn Iterator<Item = PointOfInterest> + '_> {
+        let bbox = *bbox;
+        Box::new(
+            self.pois
+                .iter()
+                .filter(move |p| bbox.contains(&p.location))
+                .cloned(),
+        )
+    }
+}

--- a/wildside-core/src/test_support.rs
+++ b/wildside-core/src/test_support.rs
@@ -1,7 +1,7 @@
 //! Test-only, in-memory PoiStore implementation used by unit and behaviour
 //! tests.
 
-use geo::Rect;
+use geo::{Intersects, Rect};
 
 use crate::{PoiStore, PointOfInterest};
 
@@ -34,15 +34,8 @@ impl PoiStore for MemoryStore {
         Box::new(
             self.pois
                 .iter()
-                // geo::Rect::contains excludes boundary points; use explicit
-                // comparisons to retain inclusive semantics.
-                .filter(move |p| {
-                    let c = p.location;
-                    c.x >= bbox.min().x
-                        && c.x <= bbox.max().x
-                        && c.y >= bbox.min().y
-                        && c.y <= bbox.max().y
-                })
+                // `Intersects` treats boundary points as inside the rectangle.
+                .filter(move |p| bbox.intersects(&p.location))
                 .cloned(),
         )
     }

--- a/wildside-core/src/test_support.rs
+++ b/wildside-core/src/test_support.rs
@@ -16,12 +16,17 @@ pub struct MemoryStore {
 impl MemoryStore {
     /// Create a store containing a single point of interest.
     pub fn with_poi(poi: PointOfInterest) -> Self {
-        Self { pois: vec![poi] }
+        Self::with_pois(std::iter::once(poi))
     }
 
     /// Create a store from a collection of points of interest.
-    pub fn with_pois(pois: Vec<PointOfInterest>) -> Self {
-        Self { pois }
+    pub fn with_pois<I>(pois: I) -> Self
+    where
+        I: IntoIterator<Item = PointOfInterest>,
+    {
+        Self {
+            pois: pois.into_iter().collect(),
+        }
     }
 }
 

--- a/wildside-core/src/test_support.rs
+++ b/wildside-core/src/test_support.rs
@@ -1,3 +1,6 @@
+//! Test-only, in-memory PoiStore implementation used by unit and behaviour
+//! tests.
+
 use geo::Rect;
 
 use crate::{PoiStore, PointOfInterest};
@@ -5,9 +8,9 @@ use crate::{PoiStore, PointOfInterest};
 /// In-memory `PoiStore` implementation used in tests.
 ///
 /// The store performs a linear scan and is intended only for small datasets.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct MemoryStore {
-    pub pois: Vec<PointOfInterest>,
+    pois: Vec<PointOfInterest>,
 }
 
 impl MemoryStore {
@@ -15,14 +18,24 @@ impl MemoryStore {
     pub fn with_poi(poi: PointOfInterest) -> Self {
         Self { pois: vec![poi] }
     }
+
+    /// Create a store from a collection of points of interest.
+    pub fn with_pois(pois: Vec<PointOfInterest>) -> Self {
+        Self { pois }
+    }
 }
 
 impl PoiStore for MemoryStore {
-    fn get_pois_in_bbox(&self, bbox: &Rect<f64>) -> Box<dyn Iterator<Item = PointOfInterest> + '_> {
+    fn get_pois_in_bbox(
+        &self,
+        bbox: &Rect<f64>,
+    ) -> Box<dyn Iterator<Item = PointOfInterest> + Send + '_> {
         let bbox = *bbox;
         Box::new(
             self.pois
                 .iter()
+                // geo::Rect::contains excludes boundary points; use explicit
+                // comparisons to retain inclusive semantics.
                 .filter(move |p| {
                     let c = p.location;
                     c.x >= bbox.min().x

--- a/wildside-core/src/test_support.rs
+++ b/wildside-core/src/test_support.rs
@@ -1,4 +1,4 @@
-use geo::{Contains, Rect};
+use geo::Rect;
 
 use crate::{PoiStore, PointOfInterest};
 
@@ -23,7 +23,13 @@ impl PoiStore for MemoryStore {
         Box::new(
             self.pois
                 .iter()
-                .filter(move |p| bbox.contains(&p.location))
+                .filter(move |p| {
+                    let c = p.location;
+                    c.x >= bbox.min().x
+                        && c.x <= bbox.max().x
+                        && c.y >= bbox.min().y
+                        && c.y <= bbox.max().y
+                })
                 .cloned(),
         )
     }

--- a/wildside-core/tests/features/poi_store.feature
+++ b/wildside-core/tests/features/poi_store.feature
@@ -9,3 +9,8 @@ Feature: PoiStore bounding box queries
     Given a store containing a single POI at the origin
     When I query the bbox that excludes the origin
     Then no POIs are returned
+
+  Scenario: Boundary inclusive
+    Given a store containing a single POI at the origin
+    When I query the bbox whose edge passes through the origin
+    Then one POI is returned

--- a/wildside-core/tests/features/poi_store.feature
+++ b/wildside-core/tests/features/poi_store.feature
@@ -19,3 +19,8 @@ Feature: PoiStore bounding box queries
     Given a store containing a single POI at the origin
     When I query the bbox whose edge passes through the origin
     Then one POI is returned
+
+  Scenario: POI returned with reversed bbox corners
+    Given a store containing a single POI at the origin
+    When I query the bbox defined with reversed corners but covering the origin
+    Then one POI is returned

--- a/wildside-core/tests/features/poi_store.feature
+++ b/wildside-core/tests/features/poi_store.feature
@@ -1,0 +1,11 @@
+Feature: PoiStore bounding box queries
+
+  Scenario: POI returned
+    Given a store containing a single POI at the origin
+    When I query the bbox covering the origin
+    Then one POI is returned
+
+  Scenario: Empty when outside bbox
+    Given a store containing a single POI at the origin
+    When I query the bbox that excludes the origin
+    Then no POIs are returned

--- a/wildside-core/tests/features/poi_store.feature
+++ b/wildside-core/tests/features/poi_store.feature
@@ -1,5 +1,10 @@
 Feature: PoiStore bounding box queries
 
+  # Notes:
+  # - Coordinates are in a Cartesian plane for tests.
+  # - Containment is boundary-inclusive (points on the bbox edge count as contained).
+  # - Units are abstract; values are dimensionless test fixtures.
+
   Scenario: POI returned
     Given a store containing a single POI at the origin
     When I query the bbox covering the origin
@@ -10,7 +15,7 @@ Feature: PoiStore bounding box queries
     When I query the bbox that excludes the origin
     Then no POIs are returned
 
-  Scenario: Boundary inclusive
+  Scenario: POI returned when on bbox boundary
     Given a store containing a single POI at the origin
     When I query the bbox whose edge passes through the origin
     Then one POI is returned

--- a/wildside-core/tests/poi_store_behaviour.rs
+++ b/wildside-core/tests/poi_store_behaviour.rs
@@ -1,3 +1,5 @@
+//! Behavioural tests for `PoiStore` bounding-box queries.
+
 use geo::{Coord, Rect};
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};

--- a/wildside-core/tests/poi_store_behaviour.rs
+++ b/wildside-core/tests/poi_store_behaviour.rs
@@ -1,45 +1,31 @@
-use geo::{Contains, Coord, Rect};
+use geo::{Coord, Rect};
 use rstest_bdd_macros::{given, scenario, then, when};
 use std::cell::RefCell;
 
-use wildside_core::{PoiStore, PointOfInterest};
+use wildside_core::{PoiStore, PointOfInterest, test_support::MemoryStore};
 
-struct MemoryStore {
-    pois: Vec<PointOfInterest>,
+thread_local! {
+    static RESULT: RefCell<Vec<PointOfInterest>> = const { RefCell::new(Vec::new()) };
 }
-
-impl PoiStore for MemoryStore {
-    fn get_pois_in_bbox(&self, bbox: &Rect<f64>) -> Vec<PointOfInterest> {
-        self.pois
-            .iter()
-            .filter(|p| bbox.contains(&p.location))
-            .cloned()
-            .collect()
-    }
-}
-
-thread_local! { static RESULT: RefCell<Option<Vec<PointOfInterest>>> = const { RefCell::new(None) }; }
 
 #[given("a store containing a single POI at the origin")]
 fn store() -> MemoryStore {
+    RESULT.with(|cell| cell.borrow_mut().clear());
     let poi = PointOfInterest::with_empty_tags(1, Coord { x: 0.0, y: 0.0 });
-    MemoryStore { pois: vec![poi] }
+    MemoryStore::with_poi(poi)
 }
 
 #[when("I query the bbox covering the origin")]
 fn query_hit() {
     let store = store();
     let bbox = Rect::new(Coord { x: -1.0, y: -1.0 }, Coord { x: 1.0, y: 1.0 });
-    let res = store.get_pois_in_bbox(&bbox);
-    RESULT.with(|cell| cell.replace(Some(res)));
+    let res: Vec<_> = store.get_pois_in_bbox(&bbox).collect();
+    RESULT.with(|cell| *cell.borrow_mut() = res);
 }
 
 #[then("one POI is returned")]
 fn one_poi() {
-    RESULT.with(|cell| {
-        let result = cell.borrow();
-        assert_eq!(result.as_ref().unwrap().len(), 1);
-    });
+    RESULT.with(|cell| assert_eq!(cell.borrow().len(), 1));
 }
 
 #[scenario(path = "tests/features/poi_store.feature", index = 0)]
@@ -49,16 +35,13 @@ fn poi_returned() {}
 fn query_miss() {
     let store = store();
     let bbox = Rect::new(Coord { x: 2.0, y: 2.0 }, Coord { x: 3.0, y: 3.0 });
-    let res = store.get_pois_in_bbox(&bbox);
-    RESULT.with(|cell| cell.replace(Some(res)));
+    let res: Vec<_> = store.get_pois_in_bbox(&bbox).collect();
+    RESULT.with(|cell| *cell.borrow_mut() = res);
 }
 
 #[then("no POIs are returned")]
 fn no_poi() {
-    RESULT.with(|cell| {
-        let result = cell.borrow();
-        assert!(result.as_ref().unwrap().is_empty());
-    });
+    RESULT.with(|cell| assert!(cell.borrow().is_empty()));
 }
 
 #[scenario(path = "tests/features/poi_store.feature", index = 1)]

--- a/wildside-core/tests/poi_store_behaviour.rs
+++ b/wildside-core/tests/poi_store_behaviour.rs
@@ -6,6 +6,10 @@ use rstest_bdd_macros::{given, scenario, then, when};
 use std::cell::RefCell;
 use wildside_core::{PoiStore, PointOfInterest, test_support::MemoryStore};
 
+fn bbox(x1: f64, y1: f64, x2: f64, y2: f64) -> Rect<f64> {
+    Rect::new(Coord { x: x1, y: y1 }, Coord { x: x2, y: y2 })
+}
+
 #[fixture]
 fn store() -> MemoryStore {
     let poi = PointOfInterest::with_empty_tags(1, Coord { x: 0.0, y: 0.0 });
@@ -30,7 +34,7 @@ fn query_hit(
     #[from(store)] store: &MemoryStore,
     #[from(results)] results: &RefCell<Vec<PointOfInterest>>,
 ) {
-    let bbox = Rect::new(Coord { x: -1.0, y: -1.0 }, Coord { x: 1.0, y: 1.0 });
+    let bbox = bbox(-1.0, -1.0, 1.0, 1.0);
     *results.borrow_mut() = store.get_pois_in_bbox(&bbox).collect();
 }
 
@@ -39,7 +43,7 @@ fn query_miss(
     #[from(store)] store: &MemoryStore,
     #[from(results)] results: &RefCell<Vec<PointOfInterest>>,
 ) {
-    let bbox = Rect::new(Coord { x: 2.0, y: 2.0 }, Coord { x: 3.0, y: 3.0 });
+    let bbox = bbox(2.0, 2.0, 3.0, 3.0);
     *results.borrow_mut() = store.get_pois_in_bbox(&bbox).collect();
 }
 
@@ -48,16 +52,29 @@ fn query_boundary_hit(
     #[from(store)] store: &MemoryStore,
     #[from(results)] results: &RefCell<Vec<PointOfInterest>>,
 ) {
-    let bbox = Rect::new(Coord { x: 0.0, y: -1.0 }, Coord { x: 1.0, y: 1.0 });
+    let bbox = bbox(0.0, -1.0, 1.0, 1.0);
+    *results.borrow_mut() = store.get_pois_in_bbox(&bbox).collect();
+}
+
+#[when("I query the bbox defined with reversed corners but covering the origin")]
+fn query_hit_reversed(
+    #[from(store)] store: &MemoryStore,
+    #[from(results)] results: &RefCell<Vec<PointOfInterest>>,
+) {
+    let bbox = bbox(1.0, 1.0, -1.0, -1.0);
     *results.borrow_mut() = store.get_pois_in_bbox(&bbox).collect();
 }
 
 #[then("one POI is returned")]
 fn one_poi(#[from(results)] results: &RefCell<Vec<PointOfInterest>>) {
+    let results = results.borrow();
+    assert_eq!(results.len(), 1, "expected exactly one POI within the bbox");
+    // Also verify identity/content
+    let poi = results.first().expect("one result present");
     assert_eq!(
-        results.borrow().len(),
-        1,
-        "expected exactly one POI within the bbox"
+        poi.location,
+        Coord { x: 0.0, y: 0.0 },
+        "expected the origin POI to be returned",
     );
 }
 
@@ -81,5 +98,10 @@ fn empty_vec_when_outside_bbox(store: MemoryStore, results: RefCell<Vec<PointOfI
 
 #[scenario(path = "tests/features/poi_store.feature", index = 2)]
 fn boundary_inclusive(store: MemoryStore, results: RefCell<Vec<PointOfInterest>>) {
+    let _ = (store, results);
+}
+
+#[scenario(path = "tests/features/poi_store.feature", index = 3)]
+fn reversed_corners(store: MemoryStore, results: RefCell<Vec<PointOfInterest>>) {
     let _ = (store, results);
 }

--- a/wildside-core/tests/poi_store_behaviour.rs
+++ b/wildside-core/tests/poi_store_behaviour.rs
@@ -1,0 +1,65 @@
+use geo::{Contains, Coord, Rect};
+use rstest_bdd_macros::{given, scenario, then, when};
+use std::cell::RefCell;
+
+use wildside_core::{PoiStore, PointOfInterest};
+
+struct MemoryStore {
+    pois: Vec<PointOfInterest>,
+}
+
+impl PoiStore for MemoryStore {
+    fn get_pois_in_bbox(&self, bbox: &Rect<f64>) -> Vec<PointOfInterest> {
+        self.pois
+            .iter()
+            .filter(|p| bbox.contains(&p.location))
+            .cloned()
+            .collect()
+    }
+}
+
+thread_local! { static RESULT: RefCell<Option<Vec<PointOfInterest>>> = const { RefCell::new(None) }; }
+
+#[given("a store containing a single POI at the origin")]
+fn store() -> MemoryStore {
+    let poi = PointOfInterest::with_empty_tags(1, Coord { x: 0.0, y: 0.0 });
+    MemoryStore { pois: vec![poi] }
+}
+
+#[when("I query the bbox covering the origin")]
+fn query_hit() {
+    let store = store();
+    let bbox = Rect::new(Coord { x: -1.0, y: -1.0 }, Coord { x: 1.0, y: 1.0 });
+    let res = store.get_pois_in_bbox(&bbox);
+    RESULT.with(|cell| cell.replace(Some(res)));
+}
+
+#[then("one POI is returned")]
+fn one_poi() {
+    RESULT.with(|cell| {
+        let result = cell.borrow();
+        assert_eq!(result.as_ref().unwrap().len(), 1);
+    });
+}
+
+#[scenario(path = "tests/features/poi_store.feature", index = 0)]
+fn poi_returned() {}
+
+#[when("I query the bbox that excludes the origin")]
+fn query_miss() {
+    let store = store();
+    let bbox = Rect::new(Coord { x: 2.0, y: 2.0 }, Coord { x: 3.0, y: 3.0 });
+    let res = store.get_pois_in_bbox(&bbox);
+    RESULT.with(|cell| cell.replace(Some(res)));
+}
+
+#[then("no POIs are returned")]
+fn no_poi() {
+    RESULT.with(|cell| {
+        let result = cell.borrow();
+        assert!(result.as_ref().unwrap().is_empty());
+    });
+}
+
+#[scenario(path = "tests/features/poi_store.feature", index = 1)]
+fn empty_vec_when_outside_bbox() {}

--- a/wildside-core/tests/poi_store_behaviour.rs
+++ b/wildside-core/tests/poi_store_behaviour.rs
@@ -1,48 +1,83 @@
 use geo::{Coord, Rect};
+use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
 use std::cell::RefCell;
-
 use wildside_core::{PoiStore, PointOfInterest, test_support::MemoryStore};
 
-thread_local! {
-    static RESULT: RefCell<Vec<PointOfInterest>> = const { RefCell::new(Vec::new()) };
-}
-
-#[given("a store containing a single POI at the origin")]
+#[fixture]
 fn store() -> MemoryStore {
-    RESULT.with(|cell| cell.borrow_mut().clear());
     let poi = PointOfInterest::with_empty_tags(1, Coord { x: 0.0, y: 0.0 });
     MemoryStore::with_poi(poi)
 }
 
+#[fixture]
+fn results() -> RefCell<Vec<PointOfInterest>> {
+    RefCell::new(Vec::new())
+}
+
+#[given("a store containing a single POI at the origin")]
+fn given_store(
+    #[from(store)] _store: &MemoryStore,
+    #[from(results)] results: &RefCell<Vec<PointOfInterest>>,
+) {
+    results.borrow_mut().clear();
+}
+
 #[when("I query the bbox covering the origin")]
-fn query_hit() {
-    let store = store();
+fn query_hit(
+    #[from(store)] store: &MemoryStore,
+    #[from(results)] results: &RefCell<Vec<PointOfInterest>>,
+) {
     let bbox = Rect::new(Coord { x: -1.0, y: -1.0 }, Coord { x: 1.0, y: 1.0 });
-    let res: Vec<_> = store.get_pois_in_bbox(&bbox).collect();
-    RESULT.with(|cell| *cell.borrow_mut() = res);
+    *results.borrow_mut() = store.get_pois_in_bbox(&bbox).collect();
+}
+
+#[when("I query the bbox that excludes the origin")]
+fn query_miss(
+    #[from(store)] store: &MemoryStore,
+    #[from(results)] results: &RefCell<Vec<PointOfInterest>>,
+) {
+    let bbox = Rect::new(Coord { x: 2.0, y: 2.0 }, Coord { x: 3.0, y: 3.0 });
+    *results.borrow_mut() = store.get_pois_in_bbox(&bbox).collect();
+}
+
+#[when("I query the bbox whose edge passes through the origin")]
+fn query_boundary_hit(
+    #[from(store)] store: &MemoryStore,
+    #[from(results)] results: &RefCell<Vec<PointOfInterest>>,
+) {
+    let bbox = Rect::new(Coord { x: 0.0, y: -1.0 }, Coord { x: 1.0, y: 1.0 });
+    *results.borrow_mut() = store.get_pois_in_bbox(&bbox).collect();
 }
 
 #[then("one POI is returned")]
-fn one_poi() {
-    RESULT.with(|cell| assert_eq!(cell.borrow().len(), 1));
-}
-
-#[scenario(path = "tests/features/poi_store.feature", index = 0)]
-fn poi_returned() {}
-
-#[when("I query the bbox that excludes the origin")]
-fn query_miss() {
-    let store = store();
-    let bbox = Rect::new(Coord { x: 2.0, y: 2.0 }, Coord { x: 3.0, y: 3.0 });
-    let res: Vec<_> = store.get_pois_in_bbox(&bbox).collect();
-    RESULT.with(|cell| *cell.borrow_mut() = res);
+fn one_poi(#[from(results)] results: &RefCell<Vec<PointOfInterest>>) {
+    assert_eq!(
+        results.borrow().len(),
+        1,
+        "expected exactly one POI within the bbox"
+    );
 }
 
 #[then("no POIs are returned")]
-fn no_poi() {
-    RESULT.with(|cell| assert!(cell.borrow().is_empty()));
+fn no_poi(#[from(results)] results: &RefCell<Vec<PointOfInterest>>) {
+    assert!(
+        results.borrow().is_empty(),
+        "expected no POIs within the bbox"
+    );
+}
+
+#[scenario(path = "tests/features/poi_store.feature", index = 0)]
+fn poi_returned(store: MemoryStore, results: RefCell<Vec<PointOfInterest>>) {
+    let _ = (store, results);
 }
 
 #[scenario(path = "tests/features/poi_store.feature", index = 1)]
-fn empty_vec_when_outside_bbox() {}
+fn empty_vec_when_outside_bbox(store: MemoryStore, results: RefCell<Vec<PointOfInterest>>) {
+    let _ = (store, results);
+}
+
+#[scenario(path = "tests/features/poi_store.feature", index = 2)]
+fn boundary_inclusive(store: MemoryStore, results: RefCell<Vec<PointOfInterest>>) {
+    let _ = (store, results);
+}


### PR DESCRIPTION
## Summary
- use git-sourced `rstest-bdd` and add macros crate for behavioural testing
- import `Contains` helper and streamline `MemoryStore` filtering example
- exercise bounding-box scenarios via `rstest-bdd` feature tests

## Testing
- `make fmt`
- `make check-fmt`
- `RUSTC_WRAPPER= SCCACHE_DISABLE=1 make lint`
- `RUSTC_WRAPPER= SCCACHE_DISABLE=1 make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_68ac5934d3208322a14271bfe1c589a3

## Summary by Sourcery

Add a new PoiStore trait with a get_pois_in_bbox method, update library exports and documentation, and introduce unit and BDD feature tests using rstest-bdd for bounding-box queries.

New Features:
- Introduce PoiStore trait with get_pois_in_bbox method for bounding-box POI queries

Enhancements:
- Export PoiStore in the library and include a MemoryStore example in documentation
- Update roadmap and design docs to mark the PoiStore trait as implemented and describe its abstraction

Build:
- Add rstest-bdd and rstest-bdd-macros as dev-dependencies for behavioral testing

Documentation:
- Update docs/roadmap.md and wildside-engine-design.md to reflect the new PoiStore trait

Tests:
- Add unit tests for POI retrieval inside and outside bounding boxes
- Add BDD feature tests for bounding-box scenarios using rstest-bdd and rstest-bdd-macros