### PR TITLE
Add travel time provider trait

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ clean: ## Remove build artifacts
 	$(CARGO) clean
 
 test: ## Run tests with warnings treated as errors
-	RUSTFLAGS="-D warnings" $(CARGO) test --all-targets --all-features $(BUILD_JOBS)
+	RUSTFLAGS="-D warnings" $(CARGO) test --all-targets --features test-support $(BUILD_JOBS)
 
 target/%/$(APP): ## Build binary in debug or release mode
 	$(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin $(APP)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -38,7 +38,7 @@ core data structures of the engine.
   - [x] Define the `TravelTimeProvider` trait with a method
   <!-- markdownlint-disable-next-line MD013 -->
   `get_travel_time_matrix(&self, pois: &[PointOfInterest]) ->
-  Result<Vec<Vec<Duration>>, TravelTimeError>`
+  Result<TravelTimeMatrix, TravelTimeError>`
 - [ ] Define the `Scorer` trait with a
   `score(&self, poi: &PointOfInterest, profile: &InterestProfile) -> f32`
   method.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -35,7 +35,7 @@ core data structures of the engine.
   <!-- markdownlint-disable-next-line MD013 -->
   `get_pois_in_bbox(&self, bbox: &geo::Rect<f64>) -> Box<dyn Iterator<Item =
   PointOfInterest> + Send + '_>`
-- [ ] Define the `TravelTimeProvider` trait with a method
+  - [x] Define the `TravelTimeProvider` trait with a method
   <!-- markdownlint-disable-next-line MD013 -->
   `get_travel_time_matrix(&self, pois: &[PointOfInterest]) ->
   Result<Vec<Vec<Duration>>, Error>`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -38,7 +38,7 @@ core data structures of the engine.
   - [x] Define the `TravelTimeProvider` trait with a method
   <!-- markdownlint-disable-next-line MD013 -->
   `get_travel_time_matrix(&self, pois: &[PointOfInterest]) ->
-  Result<Vec<Vec<Duration>>, Error>`
+  Result<Vec<Vec<Duration>>, TravelTimeError>`
 - [ ] Define the `Scorer` trait with a
   `score(&self, poi: &PointOfInterest, profile: &InterestProfile) -> f32`
   method.

--- a/docs/wildside-engine-design.md
+++ b/docs/wildside-engine-design.md
@@ -56,7 +56,7 @@ providing a stable vocabulary across crates.
   [`wildside_core::store::PoiStore`](../wildside-core/src/store.rs); indexing
   strategy is left to implementers.
 <!-- markdownlint-disable-next-line MD013 -->
-- `TravelTimeProvider` produces an `n x n` matrix of `Duration` values for a
+- `TravelTimeProvider` produces an `n×n` matrix of `Duration` values for a
   slice of POIs via
   <!-- markdownlint-disable-next-line MD013 -->
   `get_travel_time_matrix(&self, pois: &[PointOfInterest]) -> Result<TravelTimeMatrix, TravelTimeError>`

--- a/docs/wildside-engine-design.md
+++ b/docs/wildside-engine-design.md
@@ -59,8 +59,8 @@ providing a stable vocabulary across crates.
 - `TravelTimeProvider` produces an `n×n` matrix of `Duration` values for a
   slice of POIs via
   <!-- markdownlint-disable-next-line MD013 -->
-  `get_travel_time_matrix(&self, pois: &[PointOfInterest]) -> Result<TravelTimeMatrix, TravelTimeError>`
-  . The method returns an error if called with an empty slice, ensuring callers
+  `get_travel_time_matrix(&self, pois: &[PointOfInterest]) -> Result<TravelTimeMatrix, TravelTimeError>`.
+   The method returns an error if called with an empty slice, ensuring callers
   validate inputs before requesting travel times.
 
 - Test utilities such as an in-memory `PoiStore` and a unit travel time
@@ -470,8 +470,8 @@ component to provide the walking time between every pair of candidate POIs.
 This is handled by the synchronous `TravelTimeProvider` trait defined in
 `wildside-core`. The trait has the signature:
 <!-- markdownlint-disable-next-line MD013 -->
-`fn get_travel_time_matrix(&self, pois: &[PointOfInterest]) -> Result<TravelTimeMatrix, TravelTimeError>`
-. Keeping the solver synchronous preserves object safety and makes the core
+`fn get_travel_time_matrix(&self, pois: &[PointOfInterest]) -> Result<TravelTimeMatrix, TravelTimeError>`.
+ Keeping the solver synchronous preserves object safety and makes the core
 embeddable.
 
 The recommended implementation will be an adapter that makes API calls to an

--- a/docs/wildside-engine-design.md
+++ b/docs/wildside-engine-design.md
@@ -63,9 +63,9 @@ providing a stable vocabulary across crates.
    The method returns an error if called with an empty slice, ensuring callers
   validate inputs before requesting travel times.
 
-- Test utilities such as an in-memory `PoiStore` and a unit travel time
-  provider are gated behind a `test-support` feature so production consumers do
-  not inadvertently depend on them.
+- Test utilities such as an in-memory `PoiStore` and a unit travel-time
+  provider compile automatically in tests and are gated behind a `test-support`
+  feature for consumers, preventing accidental production dependencies.
 
 These definitions form the backbone of the recommendation engine; higher level
 components such as scorers and solvers operate exclusively on these types.

--- a/docs/wildside-engine-design.md
+++ b/docs/wildside-engine-design.md
@@ -59,9 +59,13 @@ providing a stable vocabulary across crates.
 - `TravelTimeProvider` produces an `n x n` matrix of `Duration` values for a
   slice of POIs via
   <!-- markdownlint-disable-next-line MD013 -->
-  `get_travel_time_matrix(&self, pois: &[PointOfInterest]) -> Result<TravelTimeMatrix, TravelTimeError>`.
-   The method returns an error if called with an empty slice, ensuring callers
+  `get_travel_time_matrix(&self, pois: &[PointOfInterest]) -> Result<TravelTimeMatrix, TravelTimeError>`
+  . The method returns an error if called with an empty slice, ensuring callers
   validate inputs before requesting travel times.
+
+- Test utilities such as an in-memory `PoiStore` and a unit travel time
+  provider are gated behind a `test-support` feature so production consumers do
+  not inadvertently depend on them.
 
 These definitions form the backbone of the recommendation engine; higher level
 components such as scorers and solvers operate exclusively on these types.
@@ -466,8 +470,8 @@ component to provide the walking time between every pair of candidate POIs.
 This is handled by the synchronous `TravelTimeProvider` trait defined in
 `wildside-core`. The trait has the signature:
 <!-- markdownlint-disable-next-line MD013 -->
-`fn get_travel_time_matrix(&self, pois: &[PointOfInterest]) -> Result<TravelTimeMatrix, TravelTimeError>`.
- Keeping the solver synchronous preserves object safety and makes the core
+`fn get_travel_time_matrix(&self, pois: &[PointOfInterest]) -> Result<TravelTimeMatrix, TravelTimeError>`
+. Keeping the solver synchronous preserves object safety and makes the core
 embeddable.
 
 The recommended implementation will be an adapter that makes API calls to an

--- a/docs/wildside-engine-design.md
+++ b/docs/wildside-engine-design.md
@@ -47,19 +47,21 @@ providing a stable vocabulary across crates.
 - `Route` contains the ordered list of `PointOfInterest` values selected for a
   tour and the overall `Duration` required to visit them. `Route::new` and
   `Route::empty` offer clear constructors.
-<!-- markdownlint-disable line-length -->
+<!-- markdownlint-disable-next-line MD013 -->
 - `PoiStore` abstracts read-only POI access. The
+  <!-- markdownlint-disable-next-line MD013 -->
   `get_pois_in_bbox(&self, bbox: &geo::Rect<f64>) -> Box<dyn Iterator<Item = PointOfInterest> + Send + '_>`
   method returns all POIs inside an axis-aligned bounding box (WGS84;
   `x = longitude`, `y = latitude`). The full semantics are documented in
   [`wildside_core::store::PoiStore`](../wildside-core/src/store.rs); indexing
   strategy is left to implementers.
+<!-- markdownlint-disable-next-line MD013 -->
 - `TravelTimeProvider` produces an `n x n` matrix of `Duration` values for a
   slice of POIs via
-  `get_travel_time_matrix(&self, pois: &[PointOfInterest]) -> Result<Vec<Vec<Duration>>, TravelTimeError>`.
+  <!-- markdownlint-disable-next-line MD013 -->
+  `get_travel_time_matrix(&self, pois: &[PointOfInterest]) -> Result<TravelTimeMatrix, TravelTimeError>`.
    The method returns an error if called with an empty slice, ensuring callers
   validate inputs before requesting travel times.
-<!-- markdownlint-enable line-length -->
 
 These definitions form the backbone of the recommendation engine; higher level
 components such as scorers and solvers operate exclusively on these types.
@@ -455,16 +457,18 @@ implementation behind a feature flag, consumers of the Wildside engine can
 choose to opt into this complexity only if they absolutely need it, without
 burdening the default setup.
 
-### 4.4. The Asynchronous Boundary: The `TravelTimeProvider`
+### 4.4. The `TravelTimeProvider` boundary
 
 A critical prerequisite for any VRP solver is the travel time matrix. The
 solver itself is an abstract mathematical engine; it requires an external
 component to provide the walking time between every pair of candidate POIs.
 
-This is handled by the `TravelTimeProvider` trait defined in `wildside-core`.
-This trait forms the asynchronous boundary for the library with the signature
-`async fn get_travel_time_matrix(...) -> Result<..., core::Error>`. Keeping the
-solver synchronous preserves object safety and makes the core embeddable.
+This is handled by the synchronous `TravelTimeProvider` trait defined in
+`wildside-core`. The trait has the signature
+<!-- markdownlint-disable-next-line MD013 -->
+`fn get_travel_time_matrix(&self, pois: &[PointOfInterest]) -> Result<TravelTimeMatrix, TravelTimeError>`.
+ Keeping the solver synchronous preserves object safety and makes the core
+embeddable.
 
 The recommended implementation will be an adapter that makes API calls to an
 external, open-source routing engine like OSRM or Valhalla, running as a

--- a/docs/wildside-engine-design.md
+++ b/docs/wildside-engine-design.md
@@ -50,10 +50,15 @@ providing a stable vocabulary across crates.
 <!-- markdownlint-disable line-length -->
 - `PoiStore` abstracts read-only POI access. The
   `get_pois_in_bbox(&self, bbox: &geo::Rect<f64>) -> Box<dyn Iterator<Item = PointOfInterest> + Send + '_>`
-   method returns all POIs inside an axis-aligned bounding box (WGS84;
+  method returns all POIs inside an axis-aligned bounding box (WGS84;
   `x = longitude`, `y = latitude`). The full semantics are documented in
   [`wildside_core::store::PoiStore`](../wildside-core/src/store.rs); indexing
   strategy is left to implementers.
+- `TravelTimeProvider` produces an `n x n` matrix of `Duration` values for a
+  slice of POIs via
+  `get_travel_time_matrix(&self, pois: &[PointOfInterest]) -> Result<Vec<Vec<Duration>>, TravelTimeError>`.
+   The method returns an error if called with an empty slice, ensuring callers
+  validate inputs before requesting travel times.
 <!-- markdownlint-enable line-length -->
 
 These definitions form the backbone of the recommendation engine; higher level

--- a/docs/wildside-engine-design.md
+++ b/docs/wildside-engine-design.md
@@ -464,7 +464,7 @@ solver itself is an abstract mathematical engine; it requires an external
 component to provide the walking time between every pair of candidate POIs.
 
 This is handled by the synchronous `TravelTimeProvider` trait defined in
-`wildside-core`. The trait has the signature
+`wildside-core`. The trait has the signature:
 <!-- markdownlint-disable-next-line MD013 -->
 `fn get_travel_time_matrix(&self, pois: &[PointOfInterest]) -> Result<TravelTimeMatrix, TravelTimeError>`.
  Keeping the solver synchronous preserves object safety and makes the core

--- a/wildside-core/Cargo.toml
+++ b/wildside-core/Cargo.toml
@@ -18,4 +18,4 @@ serde_json = "1"
 [features]
 default = []
 serde = ["dep:serde"]
-test-utils = []
+test-support = []

--- a/wildside-core/src/lib.rs
+++ b/wildside-core/src/lib.rs
@@ -14,5 +14,5 @@ pub use store::PoiStore;
 pub use theme::Theme;
 pub use travel_time::{TravelTimeError, TravelTimeMatrix, TravelTimeProvider};
 
-#[cfg(any(test, feature = "test-utils"))]
+#[cfg(feature = "test-support")]
 pub mod test_support;

--- a/wildside-core/src/lib.rs
+++ b/wildside-core/src/lib.rs
@@ -5,12 +5,14 @@ pub mod profile;
 pub mod route;
 pub mod store;
 pub mod theme;
+pub mod travel_time;
 
 pub use poi::PointOfInterest;
 pub use profile::InterestProfile;
 pub use route::Route;
 pub use store::PoiStore;
 pub use theme::Theme;
+pub use travel_time::{TravelTimeError, TravelTimeProvider};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_support;

--- a/wildside-core/src/lib.rs
+++ b/wildside-core/src/lib.rs
@@ -12,7 +12,7 @@ pub use profile::InterestProfile;
 pub use route::Route;
 pub use store::PoiStore;
 pub use theme::Theme;
-pub use travel_time::{TravelTimeError, TravelTimeProvider};
+pub use travel_time::{TravelTimeError, TravelTimeMatrix, TravelTimeProvider};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_support;

--- a/wildside-core/src/lib.rs
+++ b/wildside-core/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(doc_cfg)]
+
 //! Core domain types for the Wildside engine.
 
 pub mod poi;
@@ -14,7 +16,10 @@ pub use store::PoiStore;
 pub use theme::Theme;
 pub use travel_time::{TravelTimeError, TravelTimeMatrix, TravelTimeProvider};
 
-#[cfg(feature = "test-support")]
+#[cfg(any(test, feature = "test-support"))]
+#[cfg_attr(not(test), doc(cfg(feature = "test-support")))]
 pub mod test_support;
-#[cfg(feature = "test-support")]
+
+#[cfg(any(test, feature = "test-support"))]
+#[cfg_attr(not(test), doc(cfg(feature = "test-support")))]
 pub use crate::test_support::*;

--- a/wildside-core/src/lib.rs
+++ b/wildside-core/src/lib.rs
@@ -16,3 +16,5 @@ pub use travel_time::{TravelTimeError, TravelTimeMatrix, TravelTimeProvider};
 
 #[cfg(feature = "test-support")]
 pub mod test_support;
+#[cfg(feature = "test-support")]
+pub use crate::test_support::*;

--- a/wildside-core/src/test_support.rs
+++ b/wildside-core/src/test_support.rs
@@ -4,7 +4,7 @@
 use geo::{Intersects, Rect};
 use std::time::Duration;
 
-use crate::{PoiStore, PointOfInterest, TravelTimeError, TravelTimeProvider};
+use crate::{PoiStore, PointOfInterest, TravelTimeError, TravelTimeMatrix, TravelTimeProvider};
 
 /// In-memory `PoiStore` implementation used in tests.
 ///
@@ -48,25 +48,21 @@ impl PoiStore for MemoryStore {
 }
 
 /// Deterministic `TravelTimeProvider` returning one-second edges.
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Copy, Clone)]
 pub struct UnitTravelTimeProvider;
 
 impl TravelTimeProvider for UnitTravelTimeProvider {
     fn get_travel_time_matrix(
         &self,
         pois: &[PointOfInterest],
-    ) -> Result<Vec<Vec<Duration>>, TravelTimeError> {
+    ) -> Result<TravelTimeMatrix, TravelTimeError> {
         if pois.is_empty() {
             return Err(TravelTimeError::EmptyInput);
         }
         let n = pois.len();
-        let mut matrix = vec![vec![Duration::ZERO; n]; n];
+        let mut matrix = vec![vec![Duration::from_secs(1); n]; n];
         for (i, row) in matrix.iter_mut().enumerate() {
-            for (j, cell) in row.iter_mut().enumerate() {
-                if i != j {
-                    *cell = Duration::from_secs(1);
-                }
-            }
+            row[i] = Duration::ZERO;
         }
         Ok(matrix)
     }

--- a/wildside-core/src/test_support.rs
+++ b/wildside-core/src/test_support.rs
@@ -1,4 +1,4 @@
-//! Test-only, in-memory PoiStore implementation used by unit and behaviour
+//! Test-only, in-memory `PoiStore` implementation used by unit and behaviour
 //! tests.
 
 use geo::{Intersects, Rect};

--- a/wildside-core/src/test_support.rs
+++ b/wildside-core/src/test_support.rs
@@ -48,11 +48,13 @@ impl PoiStore for MemoryStore {
 }
 
 /// Deterministic `TravelTimeProvider` returning one-second edges.
-#[cfg(feature = "test-support")]
+#[cfg(any(test, feature = "test-support"))]
+#[cfg_attr(not(test), doc(cfg(feature = "test-support")))]
 #[derive(Default, Debug, Copy, Clone)]
 pub struct UnitTravelTimeProvider;
 
-#[cfg(feature = "test-support")]
+#[cfg(any(test, feature = "test-support"))]
+#[cfg_attr(not(test), doc(cfg(feature = "test-support")))]
 impl TravelTimeProvider for UnitTravelTimeProvider {
     fn get_travel_time_matrix(
         &self,

--- a/wildside-core/src/test_support.rs
+++ b/wildside-core/src/test_support.rs
@@ -48,9 +48,11 @@ impl PoiStore for MemoryStore {
 }
 
 /// Deterministic `TravelTimeProvider` returning one-second edges.
+#[cfg(feature = "test-support")]
 #[derive(Default, Debug, Copy, Clone)]
 pub struct UnitTravelTimeProvider;
 
+#[cfg(feature = "test-support")]
 impl TravelTimeProvider for UnitTravelTimeProvider {
     fn get_travel_time_matrix(
         &self,

--- a/wildside-core/src/travel_time.rs
+++ b/wildside-core/src/travel_time.rs
@@ -1,0 +1,105 @@
+//! Compute travel times between points of interest.
+//!
+//! The `TravelTimeProvider` trait abstracts the retrieval of pairwise travel
+//! times between [`PointOfInterest`] instances. Callers supply a slice of POIs
+//! and receive an adjacency matrix of [`Duration`] values.
+//!
+//! Errors are returned when inputs are invalid, e.g. an empty slice.
+
+use std::time::Duration;
+use thiserror::Error;
+
+use crate::PointOfInterest;
+
+/// Errors from [`TravelTimeProvider::get_travel_time_matrix`].
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum TravelTimeError {
+    /// No points of interest were provided.
+    ///
+    /// The provider requires at least one POI to compute a matrix. Callers
+    /// should pre-filter input to avoid this condition.
+    #[error("at least one point of interest is required")]
+    EmptyInput,
+}
+
+/// Fetch pairwise travel times for a set of POIs.
+///
+/// Implementers are expected to return a square `n x n` matrix where `n` equals
+/// the number of input POIs. `matrix[i][j]` represents the travel time from
+/// `pois[i]` to `pois[j]`.
+///
+/// # Examples
+///
+/// ```
+/// use std::time::Duration;
+/// use geo::Coord;
+/// use wildside_core::{PointOfInterest, TravelTimeProvider};
+/// use wildside_core::travel_time::{TravelTimeError, TravelTimeProvider as _};
+///
+/// struct UnitProvider;
+///
+/// impl TravelTimeProvider for UnitProvider {
+///     fn get_travel_time_matrix(
+///         &self,
+///         pois: &[PointOfInterest],
+///     ) -> Result<Vec<Vec<Duration>>, TravelTimeError> {
+///         if pois.is_empty() {
+///             return Err(TravelTimeError::EmptyInput);
+///         }
+///         let n = pois.len();
+///         Ok((0..n)
+///             .map(|i| {
+///                 (0..n)
+///                     .map(|j| if i == j { Duration::ZERO } else { Duration::from_secs(1) })
+///                     .collect::<Vec<_>>()
+///             })
+///             .collect::<Vec<_>>())
+///     }
+/// }
+///
+/// let poi = PointOfInterest::with_empty_tags(1, Coord { x: 0.0, y: 0.0 });
+/// let matrix = UnitProvider.get_travel_time_matrix(&[poi])?;
+/// assert_eq!(matrix.len(), 1);
+/// # Ok::<(), TravelTimeError>(())
+/// ```
+pub trait TravelTimeProvider {
+    /// Return a matrix of travel times for `pois`.
+    fn get_travel_time_matrix(
+        &self,
+        pois: &[PointOfInterest],
+    ) -> Result<Vec<Vec<Duration>>, TravelTimeError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use geo::Coord;
+    use rstest::rstest;
+
+    use crate::test_support::UnitTravelTimeProvider;
+
+    fn sample_pois() -> Vec<PointOfInterest> {
+        vec![
+            PointOfInterest::with_empty_tags(1, Coord { x: 0.0, y: 0.0 }),
+            PointOfInterest::with_empty_tags(2, Coord { x: 1.0, y: 1.0 }),
+        ]
+    }
+
+    #[rstest]
+    fn returns_square_matrix() {
+        let provider = UnitTravelTimeProvider;
+        let pois = sample_pois();
+        let matrix = provider.get_travel_time_matrix(&pois).unwrap();
+        assert_eq!(matrix.len(), pois.len());
+        assert!(matrix.iter().all(|row| row.len() == pois.len()));
+        assert_eq!(matrix[0][0], Duration::ZERO);
+        assert_eq!(matrix[0][1], Duration::from_secs(1));
+    }
+
+    #[rstest]
+    fn errors_on_empty_input() {
+        let provider = UnitTravelTimeProvider;
+        let err = provider.get_travel_time_matrix(&[]).unwrap_err();
+        assert_eq!(err, TravelTimeError::EmptyInput);
+    }
+}

--- a/wildside-core/src/travel_time/error.rs
+++ b/wildside-core/src/travel_time/error.rs
@@ -1,6 +1,9 @@
+//! Travel time errors returned by `TravelTimeProvider` implementations.
+
 use thiserror::Error;
 
 /// Errors from [`crate::travel_time::TravelTimeProvider::get_travel_time_matrix`].
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum TravelTimeError {
     /// No points of interest were provided.

--- a/wildside-core/src/travel_time/error.rs
+++ b/wildside-core/src/travel_time/error.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 
 /// Errors from [`crate::travel_time::TravelTimeProvider::get_travel_time_matrix`].
 #[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum TravelTimeError {
     /// No points of interest were provided.

--- a/wildside-core/src/travel_time/error.rs
+++ b/wildside-core/src/travel_time/error.rs
@@ -1,0 +1,12 @@
+use thiserror::Error;
+
+/// Errors from [`crate::travel_time::TravelTimeProvider::get_travel_time_matrix`].
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum TravelTimeError {
+    /// No points of interest were provided.
+    ///
+    /// The provider requires at least one POI to compute a matrix. Callers
+    /// should pre-filter input to avoid this condition.
+    #[error("at least one point of interest is required")]
+    EmptyInput,
+}

--- a/wildside-core/src/travel_time/mod.rs
+++ b/wildside-core/src/travel_time/mod.rs
@@ -1,0 +1,14 @@
+//! Compute travel times between points of interest.
+//!
+//! The `TravelTimeProvider` trait abstracts the retrieval of pairwise travel
+//! times between [`PointOfInterest`](crate::PointOfInterest) values. Callers
+//! supply a slice of POIs and receive an adjacency matrix of
+//! [`Duration`](std::time::Duration) values.
+//!
+//! Errors are returned when inputs are invalid, e.g. an empty slice.
+
+mod error;
+mod provider;
+
+pub use error::TravelTimeError;
+pub use provider::{TravelTimeMatrix, TravelTimeProvider};

--- a/wildside-core/src/travel_time/provider.rs
+++ b/wildside-core/src/travel_time/provider.rs
@@ -1,3 +1,5 @@
+//! Travel-time provider trait and adjacency-matrix alias for POI pairs.
+
 use std::time::Duration;
 
 use crate::PointOfInterest;
@@ -9,7 +11,7 @@ pub type TravelTimeMatrix = Vec<Vec<Duration>>;
 
 /// Fetch pairwise travel times for a set of POIs.
 ///
-/// Implementers must return a square `n\u00d7n` matrix where `n == pois.len()`.
+/// Implementers must return a square `n×n` matrix where `n == pois.len()`.
 /// `matrix[i][j]` is the travel time from `pois[i]` to `pois[j]`.
 ///
 /// # Examples
@@ -47,6 +49,9 @@ pub type TravelTimeMatrix = Vec<Vec<Duration>>;
 /// ```
 pub trait TravelTimeProvider {
     /// Return a matrix of travel times for `pois`.
+    ///
+    /// Implementations must return `Err(TravelTimeError::EmptyInput)` when
+    /// `pois` is empty.
     fn get_travel_time_matrix(
         &self,
         pois: &[PointOfInterest],

--- a/wildside-core/tests/features/travel_time_provider.feature
+++ b/wildside-core/tests/features/travel_time_provider.feature
@@ -1,16 +1,21 @@
 Feature: Travel time provider
 
+  Background:
+    Given a provider returning unit travel times
+
   Scenario: Matrix returned for POIs
-    Given a provider returning unit distances
     When I request travel times for two POIs
     Then a 2x2 matrix is returned
 
   Scenario: Error on empty input
-    Given a provider returning unit distances
     When I request travel times for no POIs
     Then an error is returned
 
   Scenario: Single POI returns zero duration
-    Given a provider returning unit distances
     When I request travel times for one POI
     Then a 1x1 zero matrix is returned
+
+  Scenario: Three POIs return symmetric matrix
+    When I request travel times for three POIs
+    Then a 3x3 symmetric unit matrix is returned
+

--- a/wildside-core/tests/features/travel_time_provider.feature
+++ b/wildside-core/tests/features/travel_time_provider.feature
@@ -9,3 +9,8 @@ Feature: Travel time provider
     Given a provider returning unit distances
     When I request travel times for no POIs
     Then an error is returned
+
+  Scenario: Single POI returns zero duration
+    Given a provider returning unit distances
+    When I request travel times for one POI
+    Then a 1x1 zero matrix is returned

--- a/wildside-core/tests/features/travel_time_provider.feature
+++ b/wildside-core/tests/features/travel_time_provider.feature
@@ -1,0 +1,11 @@
+Feature: Travel time provider
+
+  Scenario: Matrix returned for POIs
+    Given a provider returning unit distances
+    When I request travel times for two POIs
+    Then a 2x2 matrix is returned
+
+  Scenario: Error on empty input
+    Given a provider returning unit distances
+    When I request travel times for no POIs
+    Then an error is returned

--- a/wildside-core/tests/travel_time_provider_behaviour.rs
+++ b/wildside-core/tests/travel_time_provider_behaviour.rs
@@ -67,10 +67,19 @@ fn then_matrix(#[from(result)] result: &RefCell<Result<TravelTimeMatrix, TravelT
     let matrix = borrow.as_ref().expect("expected Ok result");
     assert_eq!(matrix.len(), 2);
     assert!(matrix.iter().all(|row| row.len() == 2));
-    assert_eq!(matrix[0][0], Duration::ZERO);
-    assert_eq!(matrix[1][1], Duration::ZERO);
-    assert_eq!(matrix[0][1], Duration::from_secs(1));
-    assert_eq!(matrix[1][0], Duration::from_secs(1));
+    for (i, row) in matrix.iter().enumerate() {
+        for (j, &cell) in row.iter().enumerate() {
+            if i == j {
+                assert_eq!(cell, Duration::ZERO, "expected diagonal to be zero");
+            } else {
+                assert_eq!(
+                    cell,
+                    Duration::from_secs(1),
+                    "expected off-diagonal to be one second",
+                );
+            }
+        }
+    }
 }
 
 #[then("a 1x1 zero matrix is returned")]

--- a/wildside-core/tests/travel_time_provider_behaviour.rs
+++ b/wildside-core/tests/travel_time_provider_behaviour.rs
@@ -6,7 +6,8 @@ use rstest_bdd_macros::{given, scenario, then, when};
 use std::cell::RefCell;
 use std::time::Duration;
 use wildside_core::{
-    PointOfInterest, TravelTimeError, TravelTimeProvider, test_support::UnitTravelTimeProvider,
+    PointOfInterest, TravelTimeError, TravelTimeMatrix, TravelTimeProvider,
+    test_support::UnitTravelTimeProvider,
 };
 
 #[fixture]
@@ -15,14 +16,14 @@ fn provider() -> UnitTravelTimeProvider {
 }
 
 #[fixture]
-fn result() -> RefCell<Result<Vec<Vec<Duration>>, TravelTimeError>> {
+fn result() -> RefCell<Result<TravelTimeMatrix, TravelTimeError>> {
     RefCell::new(Ok(Vec::new()))
 }
 
 #[given("a provider returning unit distances")]
 fn given_provider(
     #[from(provider)] _provider: &UnitTravelTimeProvider,
-    #[from(result)] result: &RefCell<Result<Vec<Vec<Duration>>, TravelTimeError>>,
+    #[from(result)] result: &RefCell<Result<TravelTimeMatrix, TravelTimeError>>,
 ) {
     *result.borrow_mut() = Ok(Vec::new());
 }
@@ -30,7 +31,7 @@ fn given_provider(
 #[when("I request travel times for two POIs")]
 fn request_two(
     #[from(provider)] provider: &UnitTravelTimeProvider,
-    #[from(result)] result: &RefCell<Result<Vec<Vec<Duration>>, TravelTimeError>>,
+    #[from(result)] result: &RefCell<Result<TravelTimeMatrix, TravelTimeError>>,
 ) {
     let pois = vec![
         PointOfInterest::with_empty_tags(1, Coord { x: 0.0, y: 0.0 }),
@@ -39,32 +40,61 @@ fn request_two(
     *result.borrow_mut() = provider.get_travel_time_matrix(&pois);
 }
 
+#[when("I request travel times for one POI")]
+fn request_one(
+    #[from(provider)] provider: &UnitTravelTimeProvider,
+    #[from(result)] result: &RefCell<Result<TravelTimeMatrix, TravelTimeError>>,
+) {
+    let pois = vec![PointOfInterest::with_empty_tags(
+        1,
+        Coord { x: 0.0, y: 0.0 },
+    )];
+    *result.borrow_mut() = provider.get_travel_time_matrix(&pois);
+}
+
 #[when("I request travel times for no POIs")]
 fn request_none(
     #[from(provider)] provider: &UnitTravelTimeProvider,
-    #[from(result)] result: &RefCell<Result<Vec<Vec<Duration>>, TravelTimeError>>,
+    #[from(result)] result: &RefCell<Result<TravelTimeMatrix, TravelTimeError>>,
 ) {
     let pois: Vec<PointOfInterest> = Vec::new();
     *result.borrow_mut() = provider.get_travel_time_matrix(&pois);
 }
 
 #[then("a 2x2 matrix is returned")]
-fn then_matrix(#[from(result)] result: &RefCell<Result<Vec<Vec<Duration>>, TravelTimeError>>) {
+fn then_matrix(#[from(result)] result: &RefCell<Result<TravelTimeMatrix, TravelTimeError>>) {
     let borrow = result.borrow();
     let matrix = borrow.as_ref().expect("expected Ok result");
     assert_eq!(matrix.len(), 2);
     assert!(matrix.iter().all(|row| row.len() == 2));
+    assert_eq!(matrix[0][0], Duration::ZERO);
+    assert_eq!(matrix[1][1], Duration::ZERO);
+    assert_eq!(matrix[0][1], Duration::from_secs(1));
+    assert_eq!(matrix[1][0], Duration::from_secs(1));
+}
+
+#[then("a 1x1 zero matrix is returned")]
+fn then_single_zero(#[from(result)] result: &RefCell<Result<TravelTimeMatrix, TravelTimeError>>) {
+    let borrow = result.borrow();
+    let matrix = borrow.as_ref().expect("expected Ok result");
+    assert_eq!(matrix.len(), 1);
+    assert_eq!(matrix[0].len(), 1);
+    assert_eq!(matrix[0][0], Duration::ZERO);
 }
 
 #[then("an error is returned")]
-fn then_error(#[from(result)] result: &RefCell<Result<Vec<Vec<Duration>>, TravelTimeError>>) {
-    assert!(result.borrow().is_err(), "expected an error");
+fn then_error(#[from(result)] result: &RefCell<Result<TravelTimeMatrix, TravelTimeError>>) {
+    let borrow = result.borrow();
+    assert!(
+        matches!(&*borrow, Err(TravelTimeError::EmptyInput)),
+        "expected EmptyInput error, got {borrow:?}"
+    );
 }
 
 #[scenario(path = "tests/features/travel_time_provider.feature", index = 0)]
 fn matrix_returned(
     provider: UnitTravelTimeProvider,
-    result: RefCell<Result<Vec<Vec<Duration>>, TravelTimeError>>,
+    result: RefCell<Result<TravelTimeMatrix, TravelTimeError>>,
 ) {
     let _ = (provider, result);
 }
@@ -72,7 +102,15 @@ fn matrix_returned(
 #[scenario(path = "tests/features/travel_time_provider.feature", index = 1)]
 fn error_on_empty(
     provider: UnitTravelTimeProvider,
-    result: RefCell<Result<Vec<Vec<Duration>>, TravelTimeError>>,
+    result: RefCell<Result<TravelTimeMatrix, TravelTimeError>>,
+) {
+    let _ = (provider, result);
+}
+
+#[scenario(path = "tests/features/travel_time_provider.feature", index = 2)]
+fn single_poi_returns_zero(
+    provider: UnitTravelTimeProvider,
+    result: RefCell<Result<TravelTimeMatrix, TravelTimeError>>,
 ) {
     let _ = (provider, result);
 }

--- a/wildside-core/tests/travel_time_provider_behaviour.rs
+++ b/wildside-core/tests/travel_time_provider_behaviour.rs
@@ -6,8 +6,7 @@ use rstest_bdd_macros::{given, scenario, then, when};
 use std::cell::RefCell;
 use std::time::Duration;
 use wildside_core::{
-    PointOfInterest, TravelTimeError, TravelTimeMatrix, TravelTimeProvider,
-    test_support::UnitTravelTimeProvider,
+    PointOfInterest, TravelTimeError, TravelTimeMatrix, TravelTimeProvider, UnitTravelTimeProvider,
 };
 
 #[fixture]

--- a/wildside-core/tests/travel_time_provider_behaviour.rs
+++ b/wildside-core/tests/travel_time_provider_behaviour.rs
@@ -1,0 +1,78 @@
+//! Behavioural tests for `TravelTimeProvider` implementations.
+
+use geo::Coord;
+use rstest::fixture;
+use rstest_bdd_macros::{given, scenario, then, when};
+use std::cell::RefCell;
+use std::time::Duration;
+use wildside_core::{
+    PointOfInterest, TravelTimeError, TravelTimeProvider, test_support::UnitTravelTimeProvider,
+};
+
+#[fixture]
+fn provider() -> UnitTravelTimeProvider {
+    UnitTravelTimeProvider
+}
+
+#[fixture]
+fn result() -> RefCell<Result<Vec<Vec<Duration>>, TravelTimeError>> {
+    RefCell::new(Ok(Vec::new()))
+}
+
+#[given("a provider returning unit distances")]
+fn given_provider(
+    #[from(provider)] _provider: &UnitTravelTimeProvider,
+    #[from(result)] result: &RefCell<Result<Vec<Vec<Duration>>, TravelTimeError>>,
+) {
+    *result.borrow_mut() = Ok(Vec::new());
+}
+
+#[when("I request travel times for two POIs")]
+fn request_two(
+    #[from(provider)] provider: &UnitTravelTimeProvider,
+    #[from(result)] result: &RefCell<Result<Vec<Vec<Duration>>, TravelTimeError>>,
+) {
+    let pois = vec![
+        PointOfInterest::with_empty_tags(1, Coord { x: 0.0, y: 0.0 }),
+        PointOfInterest::with_empty_tags(2, Coord { x: 1.0, y: 1.0 }),
+    ];
+    *result.borrow_mut() = provider.get_travel_time_matrix(&pois);
+}
+
+#[when("I request travel times for no POIs")]
+fn request_none(
+    #[from(provider)] provider: &UnitTravelTimeProvider,
+    #[from(result)] result: &RefCell<Result<Vec<Vec<Duration>>, TravelTimeError>>,
+) {
+    let pois: Vec<PointOfInterest> = Vec::new();
+    *result.borrow_mut() = provider.get_travel_time_matrix(&pois);
+}
+
+#[then("a 2x2 matrix is returned")]
+fn then_matrix(#[from(result)] result: &RefCell<Result<Vec<Vec<Duration>>, TravelTimeError>>) {
+    let borrow = result.borrow();
+    let matrix = borrow.as_ref().expect("expected Ok result");
+    assert_eq!(matrix.len(), 2);
+    assert!(matrix.iter().all(|row| row.len() == 2));
+}
+
+#[then("an error is returned")]
+fn then_error(#[from(result)] result: &RefCell<Result<Vec<Vec<Duration>>, TravelTimeError>>) {
+    assert!(result.borrow().is_err(), "expected an error");
+}
+
+#[scenario(path = "tests/features/travel_time_provider.feature", index = 0)]
+fn matrix_returned(
+    provider: UnitTravelTimeProvider,
+    result: RefCell<Result<Vec<Vec<Duration>>, TravelTimeError>>,
+) {
+    let _ = (provider, result);
+}
+
+#[scenario(path = "tests/features/travel_time_provider.feature", index = 1)]
+fn error_on_empty(
+    provider: UnitTravelTimeProvider,
+    result: RefCell<Result<Vec<Vec<Duration>>, TravelTimeError>>,
+) {
+    let _ = (provider, result);
+}


### PR DESCRIPTION
## Summary
- add `TravelTimeProvider` trait and error type
- supply a deterministic test provider and unit/behaviour tests
- document travel time provider and mark roadmap item complete

## Testing
- `RUSTC_WRAPPER= make lint`
- `RUSTC_WRAPPER= make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68ae408f30208322be86e1b1258c80c8

## Summary by Sourcery

Introduce a TravelTimeProvider abstraction in wildside-core to compute pairwise travel times for POIs, supply a deterministic test implementation, validate behavior with unit and BDD tests, and update documentation and the project roadmap.

New Features:
- Define TravelTimeProvider trait and TravelTimeError for computing an n×n travel time matrix

Enhancements:
- Provide UnitTravelTimeProvider for deterministic one-second travel times and re-export new types in lib.rs

Documentation:
- Document TravelTimeProvider in the engine design guide
- Mark the TravelTimeProvider item as complete in the project roadmap

Tests:
- Add unit tests for matrix shape and error conditions
- Add behavioral BDD tests with rstest_bdd to verify provider behavior