### PR TITLE
Install bun for Mermaid diagram validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,20 @@ jobs:
             **/uv.lock
       - name: Install bun
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
+        with:
+          bun-version: "1.2.21"
       - name: Install Mermaid CLI
-        run: bun install --global @mermaid-js/mermaid-cli
+        run: bun install --global @mermaid-js/mermaid-cli@11.9.0
+      - name: Verify Mermaid CLI
+        run: mmdc --version
       - name: Install Nixie
         run: uv tool install --from git+https://github.com/leynos/nixie nixie
       - name: Validate diagrams
         run: make nixie
+      - name: Debug CLI versions
+        if: ${{ failure() }}
+        run: |
+          set -euxo pipefail
+          which mmdc
+          mmdc --version
+          bun --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,9 @@ jobs:
         with:
           bun-version: "1.2.21"
       - name: Install Mermaid CLI
-        run: bun install --global @mermaid-js/mermaid-cli@11.9.0
+        run: |
+          bun install --global @mermaid-js/mermaid-cli@11.9.0
+          bun x puppeteer browsers install chrome-headless-shell
       - name: Verify Mermaid CLI
         run: mmdc --version
       - name: Install Nixie

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,12 +44,12 @@ jobs:
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         with:
           bun-version: "1.2.21"
-      - name: Install Mermaid CLI
+      - name: Install and verify Mermaid CLI
         run: |
+          set -euxo pipefail
           bun install --global @mermaid-js/mermaid-cli@11.9.0
           bun x puppeteer browsers install chrome-headless-shell
-      - name: Verify Mermaid CLI
-        run: mmdc --version
+          mmdc --version
       - name: Install Nixie
         run: uv tool install --from git+https://github.com/leynos/nixie nixie
       - name: Validate diagrams

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,10 @@ jobs:
           cache-dependency-glob: |
             **/pyproject.toml
             **/uv.lock
+      - name: Install bun
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
+      - name: Install Mermaid CLI
+        run: bun install --global @mermaid-js/mermaid-cli
       - name: Install Nixie
         run: uv tool install --from git+https://github.com/leynos/nixie nixie
       - name: Validate diagrams


### PR DESCRIPTION
## Summary
- install bun via setup-bun before Nixie
- install Mermaid CLI globally for diagram validation

## Testing
- `make fmt`
- `RUSTC_WRAPPER= make lint`
- `RUSTC_WRAPPER= make test`


------
https://chatgpt.com/codex/tasks/task_e_68b2ce6602948322bb8581490788ba32

## Summary by Sourcery

CI:
- Set up Bun and globally install Mermaid CLI in the CI workflow for diagram validation