### PR TITLE
Add Scorer trait to core model

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -9,13 +9,13 @@ core data structures of the engine.
 
   - [x] Create the repository root directory `wildside-engine` and initialize a
         virtual workspace:
-      
+
         ```bash
         mkdir wildside-engine && cd wildside-engine
         git init
         cargo init --vcs git
         ```
-  
+
   - [x] Replace the root `Cargo.toml` with a virtual workspace manifest (no
         `[package]`), defining members: `cargo new --lib wildside-core`,
         `cargo new --lib wildside-data`, and `cargo new --bin wildside-cli`.
@@ -33,24 +33,27 @@ core data structures of the engine.
         and a `total_duration: std::time::Duration`.
   - [x] Define the `PoiStore` trait with methods like:
         <!-- markdownlint-disable-next-line MD013 -->
-        `get_pois_in_bbox(&self, bbox: &geo::Rect<f64>) -> Box<dyn Iterator<Item = PointOfInterest> + Send + '_>`
+        `get_pois_in_bbox(&self, bbox: &geo::Rect<f64>) -> Box<dyn
+        Iterator<Item = PointOfInterest> + Send + '_>`
   - [x] Define the `TravelTimeProvider` trait with a method
         <!-- markdownlint-disable-next-line MD013 -->
-        `get_travel_time_matrix(&self, pois: &[PointOfInterest]) -> Result<TravelTimeMatrix, TravelTimeError>`
-  - [ ] Define the `Scorer` trait with a
+        `get_travel_time_matrix(&self, pois: &[PointOfInterest]) ->
+        Result<TravelTimeMatrix, TravelTimeError>`
+  - [x] Define the `Scorer` trait with a
         `score(&self, poi: &PointOfInterest, profile: &InterestProfile) -> f32`
         method.
   - [ ] Define the `Solver` trait with a
-        `solve(&self, request: &SolveRequest) -> Result<SolveResponse, Error>` method.
+        `solve(&self, request: &SolveRequest) -> Result<SolveResponse, Error>`
+        method.
 
 - **Implement OSM PBF Ingestion**
-  
+
   - [ ] In `wildside-data`, add `osmpbf` and `geo` as dependencies.
   - [ ] Create a public function `ingest_osm_pbf(path: &Path)` that uses
         `osmpbf::par_map_reduce` to process a PBF file in parallel.
   - [ ] Implement the logic to filter for relevant OSM elements (e.g., nodes and
-        ways with specific tags like `historic`, `tourism`) and convert them into
-        `PointOfInterest` instances.
+        ways with specific tags like `historic`, `tourism`) and convert them
+        into `PointOfInterest` instances.
 
 - **Adopt GeoRust Primitives**
 
@@ -79,7 +82,8 @@ core data structures of the engine.
         command with arguments for the OSM PBF and Wikidata dump file paths.
   - [ ] Implement the command's handler to orchestrate the full pipeline: call
         `ingest_osm_pbf`, then the Wikidata ETL process, and finally
-        `build_spatial_index`, saving the resulting `pois.db` and `pois.rstar` files.
+        `build_spatial_index`, saving the resulting `pois.db` and `pois.rstar`
+        files.
 
 ## Phase 2: Scoring and personalization
 
@@ -89,8 +93,8 @@ This phase implements the core logic that gives the engine its intelligence.
 
   - [ ] Create the `wildside-scorer` crate.
   - [ ] Implement an offline process that iterates through `pois.db`, calculates
-        a popularity score for each POI based on its sitelink count and heritage
-        status, and normalizes the scores.
+        a popularity score for each POI based on its sitelink count and
+        heritage status, and normalizes the scores.
   - [ ] Serialize the resulting `HashMap<PoiId, f32>` of scores to a compact
         binary file (`popularity.bin`) using a library like `bincode`.
 
@@ -107,10 +111,11 @@ This phase implements the core logic that gives the engine its intelligence.
 
   - [ ] In `wildside-core`, define the `SolveRequest` struct with public
         fields for `start: geo::Coord`, `duration_minutes: u16`,
-        `interests: InterestProfile`, and a `seed: u64` for reproducible results.
-  - [ ] Define the `SolveResponse` struct to include the final `Route`, the total
-      `score`, and a `Diagnostics` struct for metrics like solve time and number
-      of candidates.
+        `interests: InterestProfile`, and a `seed: u64` for reproducible
+        results.
+  - [ ] Define the `SolveResponse` struct to include the final `Route`, the
+    total `score`, and a `Diagnostics` struct for metrics like solve time and
+    number of candidates.
 
 ## Phase 3: The orienteering problem solver
 
@@ -143,8 +148,8 @@ This phase tackles the complex route-finding algorithm.
   - [ ] Add a `solve` command to `wildside-cli` that accepts a path to a
         JSON file.
   - [ ] The command will deserialize the JSON into a `SolveRequest`, instantiate
-        the necessary components (store, scorer, solver), call the solver, and print
-        the resulting `SolveResponse` as formatted JSON.
+        the necessary components (store, scorer, solver), call the solver, and
+        print the resulting `SolveResponse` as formatted JSON.
 
 ## Phase 4: Testing, deployment, and polish
 
@@ -152,14 +157,15 @@ This phase ensures the engine is robust, reliable, and ready for integration.
 
 - **Establish Testing Discipline**
 
-  - [ ] Create a `tests/golden_routes` directory with small, well-defined problem
-        instances and their known optimal solutions in JSON format to act as
-        regression tests.
+  - [ ] Create a `tests/golden_routes` directory with small, well-defined
+    problem instances and their known optimal solutions in JSON format to act
+    as regression tests.
   - [ ] Use `proptest` to write property-based tests for the solver, asserting
-        invariants like "total route duration must not exceed Tmax" and "route must
-        start and end at the same point".
-  - [ ] Use `criterion` to create a benchmark suite that measures the P95 and P99
-        solve times for various problem sizes (e.g., 50, 100, 200 candidate POIs).
+        invariants like "total route duration must not exceed Tmax" and "route
+        must start and end at the same point".
+  - [ ] Use `criterion` to create a benchmark suite that measures the P95 and
+    P99 solve times for various problem sizes (e.g., 50, 100, 200 candidate
+    POIs).
 
 - **Implement Feature Flags**
 
@@ -167,7 +173,7 @@ This phase ensures the engine is robust, reliable, and ready for integration.
         `solver-ortools`, and `store-sqlite`.
   - [ ] Forward feature flags from member crates using `[features]` and
         `dep:`-scoped entries to ensure a single source of truth.
-  
+
         ```toml
         # In the root Cargo.toml
         [dependencies]
@@ -181,7 +187,7 @@ This phase ensures the engine is robust, reliable, and ready for integration.
         # Enable the optional dependency and forward its `sqlite` feature
         store-sqlite = ["dep:wildside-data", "wildside-data/sqlite"]
         ```
-  
+
   - [ ] Use `#[cfg(feature = "...")]` attributes to conditionally compile the
         different solver and store implementations.
 
@@ -193,7 +199,7 @@ This phase ensures the engine is robust, reliable, and ready for integration.
         `0.1.0` feature set.
 
 - **(Optional) Implement OR-Tools Solver**
-  
+
   - [ ] Create a `wildside-solver-ortools` crate, conditionally compiled
         via the `ortools` feature flag.
   - [ ] Add a dependency on a suitable OR-Tools wrapper crate.

--- a/docs/wildside-engine-design.md
+++ b/docs/wildside-engine-design.md
@@ -60,8 +60,13 @@ providing a stable vocabulary across crates.
   slice of POIs via
   <!-- markdownlint-disable-next-line MD013 -->
   `get_travel_time_matrix(&self, pois: &[PointOfInterest]) -> Result<TravelTimeMatrix, TravelTimeError>`.
-   The method returns an error if called with an empty slice, ensuring callers
+  The method returns an error if called with an empty slice, ensuring callers
   validate inputs before requesting travel times.
+
+- `Scorer` converts a `PointOfInterest` and an `InterestProfile` into a `f32`
+  relevance score. The method is deterministic and infallible; implementers
+  return `0.0` when no signals are present. This keeps scoring simple and
+  composable for different weighting strategies.
 
 - Test utilities such as an in-memory `PoiStore` and a unit travel-time
   provider compile automatically in tests and are gated behind a `test-support`
@@ -471,7 +476,7 @@ This is handled by the synchronous `TravelTimeProvider` trait defined in
 `wildside-core`. The trait has the signature:
 <!-- markdownlint-disable-next-line MD013 -->
 `fn get_travel_time_matrix(&self, pois: &[PointOfInterest]) -> Result<TravelTimeMatrix, TravelTimeError>`.
- Keeping the solver synchronous preserves object safety and makes the core
+Keeping the solver synchronous preserves object safety and makes the core
 embeddable.
 
 The recommended implementation will be an adapter that makes API calls to an

--- a/wildside-core/src/lib.rs
+++ b/wildside-core/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod poi;
 pub mod profile;
 pub mod route;
+pub mod scorer;
 pub mod store;
 pub mod theme;
 pub mod travel_time;
@@ -12,6 +13,7 @@ pub mod travel_time;
 pub use poi::PointOfInterest;
 pub use profile::InterestProfile;
 pub use route::Route;
+pub use scorer::Scorer;
 pub use store::PoiStore;
 pub use theme::Theme;
 pub use travel_time::{TravelTimeError, TravelTimeMatrix, TravelTimeProvider};

--- a/wildside-core/src/scorer.rs
+++ b/wildside-core/src/scorer.rs
@@ -1,0 +1,92 @@
+//! Score points of interest for a user profile.
+//!
+//! The `Scorer` trait assigns a relevance score to a
+//! [`PointOfInterest`](crate::PointOfInterest) given a visitor's
+//! [`InterestProfile`](crate::InterestProfile).
+
+use crate::{InterestProfile, PointOfInterest};
+
+/// Calculate a relevance score for a point of interest.
+///
+/// Higher scores indicate a better match between the POI and the
+/// caller's interests. The method is infallible; implementers must return
+/// `0.0` when no information is available.
+///
+/// # Examples
+///
+/// ```
+/// use geo::Coord;
+/// use wildside_core::{InterestProfile, PointOfInterest, Scorer};
+///
+/// struct UnitScorer;
+///
+/// impl Scorer for UnitScorer {
+///     fn score(&self, _poi: &PointOfInterest, _profile: &InterestProfile) -> f32 {
+///         1.0
+///     }
+/// }
+///
+/// let poi = PointOfInterest::with_empty_tags(1, Coord { x: 0.0, y: 0.0 });
+/// let profile = InterestProfile::new();
+/// let scorer = UnitScorer;
+/// assert_eq!(scorer.score(&poi, &profile), 1.0);
+/// ```
+pub trait Scorer {
+    /// Return a score for `poi` according to `profile`.
+    fn score(&self, poi: &PointOfInterest, profile: &InterestProfile) -> f32;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Theme, poi::Tags};
+    use geo::Coord;
+    use rstest::rstest;
+    use std::str::FromStr;
+
+    struct TagScorer;
+
+    impl Scorer for TagScorer {
+        fn score(&self, poi: &PointOfInterest, profile: &InterestProfile) -> f32 {
+            poi.tags
+                .keys()
+                .filter_map(|k| Theme::from_str(k).ok())
+                .filter_map(|t| profile.weight(&t))
+                .sum()
+        }
+    }
+
+    fn make_poi(tag: &str) -> PointOfInterest {
+        PointOfInterest::new(
+            1,
+            Coord { x: 0.0, y: 0.0 },
+            Tags::from([(tag.to_string(), String::new())]),
+        )
+    }
+
+    #[rstest]
+    fn sums_matching_weights() {
+        let mut profile = InterestProfile::new();
+        profile.set_weight(Theme::Art, 0.7);
+        let poi = make_poi("art");
+        let scorer = TagScorer;
+        assert_eq!(scorer.score(&poi, &profile), 0.7);
+    }
+
+    #[rstest]
+    fn zero_when_no_match() {
+        let mut profile = InterestProfile::new();
+        profile.set_weight(Theme::Art, 0.7);
+        let poi = make_poi("history");
+        let scorer = TagScorer;
+        assert_eq!(scorer.score(&poi, &profile), 0.0);
+    }
+
+    #[rstest]
+    fn zero_for_empty_profile() {
+        let profile = InterestProfile::new();
+        let poi = make_poi("art");
+        let scorer = TagScorer;
+        assert_eq!(scorer.score(&poi, &profile), 0.0);
+    }
+}

--- a/wildside-core/tests/features/scorer.feature
+++ b/wildside-core/tests/features/scorer.feature
@@ -1,0 +1,11 @@
+Feature: Scorer trait
+
+  Scenario: Matching tag returns weight
+    Given a POI tagged 'art' and a profile with 'art' weight 0.7
+    When I score the POI
+    Then the score is 0.7
+
+  Scenario: Non-matching tag yields zero
+    Given a POI tagged 'history' and a profile with 'art' weight 0.7
+    When I score the POI
+    Then the score is 0.0

--- a/wildside-core/tests/scorer_behaviour.rs
+++ b/wildside-core/tests/scorer_behaviour.rs
@@ -1,0 +1,101 @@
+//! Behavioural tests for `Scorer` implementations.
+
+use geo::Coord;
+use rstest::fixture;
+use rstest_bdd_macros::{given, scenario, then, when};
+use std::cell::{Cell, RefCell};
+use std::str::FromStr;
+use wildside_core::{InterestProfile, PointOfInterest, Scorer, Theme, poi::Tags};
+
+struct TagScorer;
+
+impl Scorer for TagScorer {
+    fn score(&self, poi: &PointOfInterest, profile: &InterestProfile) -> f32 {
+        poi.tags
+            .keys()
+            .filter_map(|k| Theme::from_str(k).ok())
+            .filter_map(|t| profile.weight(&t))
+            .sum()
+    }
+}
+
+#[fixture]
+fn scorer() -> TagScorer {
+    TagScorer
+}
+
+#[fixture]
+fn poi() -> RefCell<PointOfInterest> {
+    RefCell::new(PointOfInterest::with_empty_tags(
+        1,
+        Coord { x: 0.0, y: 0.0 },
+    ))
+}
+
+#[fixture]
+fn profile() -> RefCell<InterestProfile> {
+    RefCell::new(InterestProfile::new())
+}
+
+#[fixture]
+fn result() -> Cell<f32> {
+    Cell::new(0.0)
+}
+
+#[given("a POI tagged 'art' and a profile with 'art' weight 0.7")]
+fn given_matching(
+    #[from(poi)] poi: &RefCell<PointOfInterest>,
+    #[from(profile)] profile: &RefCell<InterestProfile>,
+) {
+    poi.borrow_mut().tags = Tags::from([("art".into(), String::new())]);
+    profile.borrow_mut().set_weight(Theme::Art, 0.7);
+}
+
+#[given("a POI tagged 'history' and a profile with 'art' weight 0.7")]
+fn given_non_matching(
+    #[from(poi)] poi: &RefCell<PointOfInterest>,
+    #[from(profile)] profile: &RefCell<InterestProfile>,
+) {
+    poi.borrow_mut().tags = Tags::from([("history".into(), String::new())]);
+    profile.borrow_mut().set_weight(Theme::Art, 0.7);
+}
+
+#[when("I score the POI")]
+fn when_score(
+    #[from(scorer)] scorer: &TagScorer,
+    #[from(poi)] poi: &RefCell<PointOfInterest>,
+    #[from(profile)] profile: &RefCell<InterestProfile>,
+    #[from(result)] result: &Cell<f32>,
+) {
+    result.set(scorer.score(&poi.borrow(), &profile.borrow()));
+}
+
+#[then("the score is 0.7")]
+fn then_score_0_7(#[from(result)] result: &Cell<f32>) {
+    assert!((result.get() - 0.7).abs() < f32::EPSILON);
+}
+
+#[then("the score is 0.0")]
+fn then_score_0(#[from(result)] result: &Cell<f32>) {
+    assert_eq!(result.get(), 0.0);
+}
+
+#[scenario(path = "tests/features/scorer.feature", index = 0)]
+fn match_tag(
+    scorer: TagScorer,
+    poi: RefCell<PointOfInterest>,
+    profile: RefCell<InterestProfile>,
+    result: Cell<f32>,
+) {
+    let _ = (scorer, poi, profile, result);
+}
+
+#[scenario(path = "tests/features/scorer.feature", index = 1)]
+fn miss_tag(
+    scorer: TagScorer,
+    poi: RefCell<PointOfInterest>,
+    profile: RefCell<InterestProfile>,
+    result: Cell<f32>,
+) {
+    let _ = (scorer, poi, profile, result);
+}


### PR DESCRIPTION
## Summary
- add Scorer trait for POI relevance scoring
- cover scoring with unit and behaviour tests
- document new trait and mark roadmap item done

## Testing
- ⚠️ `make fmt` (fails: MD029/ol-prefix in docs/srgn.md)
- ✅ `RUSTC_WRAPPER= make lint`
- ✅ `RUSTC_WRAPPER= make test`
- ✅ `make markdownlint`
- ✅ `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68bb6389a4388322b371f731f66b3437