### PR TITLE
Standardize optimized spelling in complexity documentation

### DIFF
--- a/docs/complexity-antipatterns-and-refactoring-strategies.md
+++ b/docs/complexity-antipatterns-and-refactoring-strategies.md
@@ -418,7 +418,7 @@ CQRS is an architectural pattern that segregates operations that modify state
 and should represent specific business intentions (e.g.,
 
 `BookHotelRoomCommand` rather than `SetReservationStatusCommand`).18 Queries
-never alter data and return Data Transfer Objects (DTOs) optimised for display
+never alter data and return Data Transfer Objects (DTOs) optimized for display
 needs.18
 
 While CQRS operates at a higher architectural level than a single Bumpy Road


### PR DESCRIPTION
## Summary
- replace the remaining British spelling of "optimised" with the American spelling in the complexity anti-patterns and refactoring strategies guide
- closes #7

## Testing
- make fmt

------
https://chatgpt.com/codex/tasks/task_e_68de63e5f0948322aa587a05be291da9

## Summary by Sourcery

Documentation:
- Replace British spelling 'optimised' with American 'optimized' in the complexity documentation