### PR TITLE
Refactor spatial index storage

### DIFF
--- a/wildside-core/src/test_support.rs
+++ b/wildside-core/src/test_support.rs
@@ -17,7 +17,7 @@ use crate::{
     TravelTimeProvider,
 };
 #[cfg(any(test, feature = "test-support"))]
-use crate::{Scorer, Theme, store::IndexedPoi, store::SpatialIndexWriteError, store::write_index};
+use crate::{Scorer, Theme, store::SpatialIndexWriteError, store::write_index};
 
 /// In-memory `PoiStore` implementation used in tests.
 ///
@@ -93,8 +93,7 @@ pub fn write_sqlite_spatial_index(
     path: &Path,
     pois: &[PointOfInterest],
 ) -> Result<(), SpatialIndexWriteError> {
-    let entries: Vec<IndexedPoi> = pois.iter().map(IndexedPoi::from).collect();
-    write_index(path, &entries)
+    write_index(path, pois)
 }
 
 /// Deterministic `TravelTimeProvider` returning one-second edges.


### PR DESCRIPTION
## Summary
- store `PointOfInterest` values directly in the persisted spatial index and drop the `IndexedPoi` wrapper
- simplify `SqlitePoiStore` error handling, load validation from a serde container, and keep query results sorted
- update the test helpers and design document to reflect the new index format

closes #44

## Testing
- make check-fmt
- RUSTC_WRAPPER= make lint
- RUSTC_WRAPPER= make test

------
https://chatgpt.com/codex/tasks/task_e_68e5badb65588322a87d00034be6e9bc