### PR TITLE
Upgrade rusqlite to v0.32.1 across workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,9 +1549,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.28.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2459,9 +2459,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
  "bitflags",
  "fallible-iterator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ rand_chacha = "0.3"
 rand_distr = "0.4"
 camino = { version = "1.2.1", features = ["serde1"] }
 cap-std = { version = "3.4.5", features = ["fs_utf8"] }
+rusqlite = { version = "0.32.1", features = ["bundled"] }
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/wildside-cli/Cargo.toml
+++ b/wildside-cli/Cargo.toml
@@ -33,7 +33,7 @@ rstest = { workspace = true }
 rstest-bdd = { workspace = true }
 rstest-bdd-macros = { workspace = true }
 tempfile = "3.23.0"
-rusqlite = { version = "0.32.1", features = ["bundled"] }
+rusqlite = { workspace = true }
 
 [features]
 default = ["solver-vrp", "store-sqlite"]

--- a/wildside-cli/Cargo.toml
+++ b/wildside-cli/Cargo.toml
@@ -33,7 +33,7 @@ rstest = { workspace = true }
 rstest-bdd = { workspace = true }
 rstest-bdd-macros = { workspace = true }
 tempfile = "3.23.0"
-rusqlite = { version = "0.31.0", features = ["bundled"] }
+rusqlite = { version = "0.32.1", features = ["bundled"] }
 
 [features]
 default = ["solver-vrp", "store-sqlite"]

--- a/wildside-core/Cargo.toml
+++ b/wildside-core/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 geo = { workspace = true }
 rstar = { version = "0.12.0" }
-rusqlite = { version = "0.31.0", features = ["bundled"], optional = true }
+rusqlite = { version = "0.32.1", features = ["bundled"], optional = true }
 thiserror = "1"
 serde = { version = "1", optional = true, features = ["derive"] }
 serde_json = { version = "1", optional = true }

--- a/wildside-core/Cargo.toml
+++ b/wildside-core/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 geo = { workspace = true }
 rstar = { version = "0.12.0" }
-rusqlite = { version = "0.32.1", features = ["bundled"], optional = true }
+rusqlite = { workspace = true, optional = true }
 thiserror = "1"
 serde = { version = "1", optional = true, features = ["derive"] }
 serde_json = { version = "1", optional = true }

--- a/wildside-data/Cargo.toml
+++ b/wildside-data/Cargo.toml
@@ -14,7 +14,7 @@ wikidata-rust = { package = "wikidata", version = "1.1.0" }
 simd-json = { version = "0.17.0", features = ["serde"] }
 # Use the vendored SQLite build to guarantee consistent behaviour across CI
 # and developer machines.
-rusqlite = { version = "0.32.1", features = ["bundled"] }
+rusqlite = { workspace = true }
 reqwest = { version = "0.12.24", default-features = false, features = ["rustls-tls", "stream", "json"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "1"

--- a/wildside-data/Cargo.toml
+++ b/wildside-data/Cargo.toml
@@ -14,7 +14,7 @@ wikidata-rust = { package = "wikidata", version = "1.1.0" }
 simd-json = { version = "0.17.0", features = ["serde"] }
 # Use the vendored SQLite build to guarantee consistent behaviour across CI
 # and developer machines.
-rusqlite = { version = "0.31.0", features = ["bundled"] }
+rusqlite = { version = "0.32.1", features = ["bundled"] }
 reqwest = { version = "0.12.24", default-features = false, features = ["rustls-tls", "stream", "json"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "1"

--- a/wildside-scorer/Cargo.toml
+++ b/wildside-scorer/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 bincode = "1.3.3"
 camino = { workspace = true }
-rusqlite = { version = "0.31.0", features = ["bundled"] }
+rusqlite = { version = "0.32.1", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"

--- a/wildside-scorer/Cargo.toml
+++ b/wildside-scorer/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 bincode = "1.3.3"
 camino = { workspace = true }
-rusqlite = { version = "0.32.1", features = ["bundled"] }
+rusqlite = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"


### PR DESCRIPTION
## Summary
- Upgrades rusqlite to 0.32.1 across all crates that depend on SQLite (workspace-wide).
- Aligns with bundled libsqlite3-sys and fixes included in the 0.32.x series.

## Changes
- root/Cargo.toml: rusqlite = { version = "0.32.1", features = ["bundled"] }
- wildside-cli/Cargo.toml: rusqlite = { workspace = true }
- wildside-core/Cargo.toml: rusqlite = { workspace = true, optional = true }
- wildside-data/Cargo.toml: rusqlite = { workspace = true }
- wildside-scorer/Cargo.toml: rusqlite = { workspace = true }
- Cargo.lock: libsqlite3-sys bumped to 0.30.1; rusqlite bumped to 0.32.1; lockfile updated accordingly

## Testing
- Build the workspace: cargo build
- Run tests: cargo test
- Smoke test CLI and any SQLite-dependent features to ensure basic functionality remains intact

## Notes
- No code changes required; this is purely a dependency upgrade.
- If any runtime issues arise, consider re-running CI with updated libsqlite3-sys or reporting to the maintainers.

📎 **Task**: https://www.devboxer.com/task/98edc9b9-236b-4270-9e90-cff6f9e1df18