### PR TITLE
Add scheduled mutation testing via the shared workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
           cache-dependency-glob: |
             **/pyproject.toml
             **/uv.lock
+      - name: Workflow contract tests
+        run: make test-workflow-contracts
       - name: Install bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,0 +1,41 @@
+name: Mutation testing
+
+# Thin caller of the shared mutation-testing reusable workflow; caller
+# guide: leynos/shared-actions docs/mutation-cargo-workflow.md.
+# Scheduled runs mutate only files changed within the detection window;
+# manual dispatch runs mutate everything, fanned out across shards. To
+# test a branch, select it in the Actions "Run workflow" control.
+
+on:
+  schedule:
+    - cron: "20 4 * * *" # Daily, 04:20 UTC
+  workflow_dispatch:
+
+# Default the token to no scopes; the job opts in explicitly.
+permissions: {}
+
+# Serialize runs per ref: a dispatch during a scheduled run (or vice
+# versa) queues rather than racing. Runs are informational, so queued
+# runs wait instead of cancelling.
+concurrency:
+  group: mutation-testing-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  mutation:
+    permissions:
+      contents: read
+      id-token: write # OIDC workflow-source resolution
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@47aea18960d24f33aedc4782ec6b73e365418313
+    with:
+      # The workspace members live beside the root crate rather than
+      # under crates/, so cover each member directory explicitly.
+      paths: "src/,wildside-cli/,wildside-core/,wildside-data/,wildside-fs/,wildside-scorer/,wildside-solver-ortools/,wildside-solver-vrp/"
+      # Feature-gated test-support scaffolding and benchmark helpers
+      # have no direct test coverage; their survivors are noise.
+      # Slash-free patterns match by file name anywhere in the tree.
+      exclude-globs: "test_support.rs,bench_support.rs"
+      # Match the CI baseline (`make test` runs with
+      # --features test-support) so the shared test-double scaffolding
+      # compiles and the full suite runs against mutants.
+      extra-args: "--features test-support"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 
 **/*.pbf
 .memdb/
+__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help all clean test bench build release lint fmt check-fmt markdownlint nixie typecheck
+.PHONY: help all clean test test-workflow-contracts bench build release lint fmt check-fmt markdownlint nixie typecheck
 
 APP ?= wildside-engine
 CARGO ?= cargo
@@ -18,6 +18,9 @@ clean: ## Remove build artifacts
 
 test: ## Run tests with warnings treated as errors
 	RUSTFLAGS="-D warnings" $(CARGO) nextest run --workspace --all-targets --features test-support $(TEST_FLAGS) $(BUILD_JOBS)
+
+test-workflow-contracts: ## Validate the mutation-testing caller contract
+	uv run --with 'pytest>=8' --with 'pyyaml>=6' pytest tests/workflow_contracts -q
 
 bench: ## Run performance benchmarks
 	$(CARGO) bench --package wildside-solver-vrp

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -1,0 +1,148 @@
+"""Contract tests for the mutation-testing caller workflow.
+
+The executable logic lives in the ``leynos/shared-actions`` reusable
+workflow, which carries its own unit and integration tests;
+wildside-engine's caller is declarative configuration. These tests parse
+the caller with PyYAML and pin the contract it must uphold, so drift
+(repointing the pin at a branch, widening permissions, or losing the
+workspace paths, scaffolding excludes, or test-support feature args)
+fails CI on the pull request rather than surfacing in a scheduled or
+manual run.
+
+Run via ``make test-workflow-contracts``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
+)
+
+#: The pinned commit of leynos/shared-actions (the merge commit of
+#: leynos/shared-actions PR #319). Bump the workflow and this test
+#: together.
+PINNED_SHA = "47aea18960d24f33aedc4782ec6b73e365418313"
+
+EXPECTED_USES = (
+    "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
+)
+
+#: The exact caller configuration: workspace member directories beside
+#: the root crate, scaffolding excludes, and the CI baseline feature
+#: flags (`make test` runs with --features test-support).
+EXPECTED_WITH = {
+    "paths": (
+        "src/,wildside-cli/,wildside-core/,wildside-data/,wildside-fs/,"
+        "wildside-scorer/,wildside-solver-ortools/,wildside-solver-vrp/"
+    ),
+    "exclude-globs": "test_support.rs,bench_support.rs",
+    "extra-args": "--features test-support",
+}
+
+
+def _load() -> dict[str, object]:
+    """Parse the workflow file."""
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _triggers(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the ``on:`` mapping (PyYAML parses the bare key as True)."""
+    triggers = workflow.get("on", workflow.get(True))
+    assert isinstance(triggers, dict), "the workflow must declare an on: mapping"
+    return triggers
+
+
+def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the single calling job."""
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), "the workflow must declare a jobs mapping"
+    assert jobs, "the workflow must declare at least one job"
+    assert list(jobs) == ["mutation"], (
+        f"expected a single job named 'mutation', found {sorted(jobs)}"
+    )
+    return jobs["mutation"]
+
+
+def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
+    """The job must call the shared workflow at the exact documented SHA."""
+    uses = _mutation_job(_load()).get("uses")
+    assert uses is not None, "jobs.mutation.uses is missing"
+    path, _, ref = uses.partition("@")
+    assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
+        f"jobs.mutation.uses must reference mutation-cargo.yml, got {path!r}"
+    )
+    assert len(ref) == 40, (
+        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert all(c in "0123456789abcdef" for c in ref), (
+        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert uses == EXPECTED_USES, (
+        f"jobs.mutation.uses pins {ref!r}; this test documents {PINNED_SHA!r} — "
+        "bump this test together with the workflow"
+    )
+
+
+def test_job_permissions_are_exactly_least_privilege() -> None:
+    """The job grants contents: read and id-token: write, nothing broader."""
+    permissions = _mutation_job(_load()).get("permissions")
+    assert permissions == {"contents": "read", "id-token": "write"}, (
+        "jobs.mutation.permissions must be exactly "
+        f"{{'contents': 'read', 'id-token': 'write'}}, got {permissions!r}"
+    )
+
+
+def test_workflow_default_permissions_are_empty() -> None:
+    """The workflow-level default token scope is empty."""
+    workflow = _load()
+    assert workflow.get("permissions") == {}, (
+        f"top-level permissions must be an empty mapping, got "
+        f"{workflow.get('permissions')!r}"
+    )
+
+
+def test_concurrency_serializes_per_ref_without_cancelling() -> None:
+    """Runs queue per ref instead of cancelling one another."""
+    concurrency = _load().get("concurrency")
+    assert isinstance(concurrency, dict), "the workflow must declare concurrency"
+    assert concurrency.get("group") == "mutation-testing-${{ github.ref }}", (
+        f"concurrency.group must key on the triggering ref, got "
+        f"{concurrency.get('group')!r}"
+    )
+    assert concurrency.get("cancel-in-progress") is False, (
+        f"concurrency.cancel-in-progress must be false, got "
+        f"{concurrency.get('cancel-in-progress')!r}"
+    )
+
+
+def test_triggers_keep_schedule_and_plain_dispatch() -> None:
+    """The daily schedule stays; dispatch has no legacy branch input."""
+    triggers = _triggers(_load())
+    schedule = triggers.get("schedule")
+    assert schedule == [{"cron": "20 4 * * *"}], (
+        f"on.schedule must be the daily 04:20 UTC cron, got {schedule!r}"
+    )
+    assert "workflow_dispatch" in triggers, "on.workflow_dispatch is missing"
+    dispatch = triggers.get("workflow_dispatch") or {}
+    inputs = dispatch.get("inputs") or {}
+    assert "branch" not in inputs, (
+        "on.workflow_dispatch must not declare a branch input; the Actions "
+        "run-workflow control selects the ref"
+    )
+
+
+def test_with_block_carries_the_caller_configuration() -> None:
+    """The caller passes exactly the documented inputs for this repo."""
+    with_block = _mutation_job(_load()).get("with")
+    assert isinstance(with_block, dict), "jobs.mutation.with is missing"
+    assert with_block == EXPECTED_WITH, (
+        "jobs.mutation.with must be exactly the documented configuration "
+        f"(workspace paths, scaffolding excludes, test-support feature args); "
+        f"expected {EXPECTED_WITH!r}, got {with_block!r}"
+    )


### PR DESCRIPTION
## Summary

This pull request adds a thin caller of the shared mutation-testing reusable workflow, `leynos/shared-actions` `mutation-cargo.yml`, pinned to commit `47aea18960d24f33aedc4782ec6b73e365418313`. The runs are informational only: a daily scheduled guard at 04:20 UTC mutates files changed within the detection window, while manual dispatch mutates everything, fanned out across shards.

## Configuration for this repository

- **paths**: `src/` plus every workspace member directory (`wildside-cli/`, `wildside-core/`, `wildside-data/`, `wildside-fs/`, `wildside-scorer/`, `wildside-solver-ortools/`, `wildside-solver-vrp/`), because the members live beside the root crate rather than under `crates/`.
- **exclude-globs**: `test_support.rs,bench_support.rs` — the feature-gated test-double scaffolding under the members' `src/` trees and the benchmark helper have no direct test coverage, so their survivors would be noise. Slash-free patterns match by file name anywhere in the tree.
- **extra-args**: `--features test-support`, mirroring the CI baseline (`make test` runs nextest with that feature) so the shared scaffolding compiles and the full suite runs against mutants.

A PyYAML contract test suite (`tests/workflow_contracts/mutation_testing_test.py`) pins the caller's shape — the exact commit SHA, least-privilege permissions, per-ref non-cancelling concurrency, the daily cron, and the exact `with:` block — and runs via the new `make test-workflow-contracts` target in the required CI `build` job, after the existing uv setup step.

## Validation

- Both workflows parse with PyYAML and pass actionlint.
- `make test-workflow-contracts`: 6 passed.
- Negative test: repointing the pin at `@v1` fails the SHA contract test as intended; restoring the pin returns the suite to green.

References: the [caller guide](https://github.com/leynos/shared-actions/blob/main/docs/mutation-cargo-workflow.md) and the estate template leynos/wireframe#572.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
