### PR TITLE
Test the whole workspace against mutants and bump the workflow pin

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC workflow-source resolution
-    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@47aea18960d24f33aedc4782ec6b73e365418313
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@2b09d10192627fd6e1034e7c12625dd266b45503
     with:
       # The workspace members live beside the root crate rather than
       # under crates/, so cover each member directory explicitly.
@@ -38,4 +38,8 @@ jobs:
       # Match the CI baseline (`make test` runs with
       # --features test-support) so the shared test-double scaffolding
       # compiles and the full suite runs against mutants.
-      extra-args: "--features test-support"
+      # --test-workspace=true runs the whole workspace's tests against
+      # each mutant; cargo-mutants otherwise runs only the mutated
+      # package's tests, so crates covered by dependent crates' tests
+      # would report false survivors.
+      extra-args: "--features test-support --test-workspace=true"

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -22,10 +22,9 @@ WORKFLOW_PATH = (
     Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
 )
 
-#: The pinned commit of leynos/shared-actions (the merge commit of
-#: leynos/shared-actions PR #319). Bump the workflow and this test
-#: together.
-PINNED_SHA = "47aea18960d24f33aedc4782ec6b73e365418313"
+#: The pinned commit of leynos/shared-actions (artefact preservation on
+#: timeout). Bump the workflow and this test together.
+PINNED_SHA = "2b09d10192627fd6e1034e7c12625dd266b45503"
 
 EXPECTED_USES = (
     "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
@@ -33,14 +32,16 @@ EXPECTED_USES = (
 
 #: The exact caller configuration: workspace member directories beside
 #: the root crate, scaffolding excludes, and the CI baseline feature
-#: flags (`make test` runs with --features test-support).
+#: flags (`make test` runs with --features test-support) plus
+#: --test-workspace=true so dependent crates' tests run against each
+#: mutant rather than only the mutated package's own tests.
 EXPECTED_WITH = {
     "paths": (
         "src/,wildside-cli/,wildside-core/,wildside-data/,wildside-fs/,"
         "wildside-scorer/,wildside-solver-ortools/,wildside-solver-vrp/"
     ),
     "exclude-globs": "test_support.rs,bench_support.rs",
-    "extra-args": "--features test-support",
+    "extra-args": "--features test-support --test-workspace=true",
 }
 
 


### PR DESCRIPTION
## Summary

Follow-up to #96, applying an estate-wide review finding from rstest-bdd#569: cargo-mutants runs only the mutated package's tests by default, so workspace crates whose coverage lives in dependent crates' tests report false survivors. This repository's CI baseline is `cargo nextest run --workspace --all-targets --features test-support`, so mutation runs should exercise the whole workspace too.

## Changes

- Append ` --test-workspace=true` to `extra-args` in `.github/workflows/mutation-testing.yml`, keeping `--features test-support`, so the whole workspace's tests run against each mutant.
- Bump the shared-workflow pin from `47aea18960d24f33aedc4782ec6b73e365418313` to `2b09d10192627fd6e1034e7c12625dd266b45503`, which preserves artefacts when a shard times out.
- Update the contract test's `PINNED_SHA` and expected `extra-args` to match.

## Validation

- The workflow parses with PyYAML and passes actionlint.
- `make test-workflow-contracts`: 6 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
