### PR TITLE
Adopt the Whitaker Dylint suite in the lint gate and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN || '' }}
       CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 || '' }}
       MERMAN_CLI_VERSION: '0.7.0'
+      WHITAKER_INSTALLER_VERSION: '0.2.6'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
         with:
@@ -31,6 +32,25 @@ jobs:
           tool: cargo-nextest
       - name: Check formatting
         run: make check-fmt
+      - name: Cache whitaker-installer
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.cargo/bin/whitaker-installer
+            ~/.cache/cargo-binstall
+          key: whitaker-installer-${{ runner.os }}-${{ runner.arch }}-${{ env.WHITAKER_INSTALLER_VERSION }}
+      - name: Install the Whitaker Dylint suite
+        run: |
+          set -euo pipefail
+          if ! command -v whitaker-installer >/dev/null 2>&1; then
+            if cargo binstall --version >/dev/null 2>&1; then
+              cargo binstall --no-confirm --locked "whitaker-installer@${WHITAKER_INSTALLER_VERSION}"
+            else
+              echo "cargo-binstall unavailable; building whitaker-installer from crates.io"
+              cargo install --locked whitaker-installer --version "${WHITAKER_INSTALLER_VERSION}"
+            fi
+          fi
+          whitaker-installer
       - name: Lint
         run: make lint
       - name: Test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3578,6 +3578,7 @@ name = "wildside-core"
 version = "0.1.0"
 dependencies = [
  "bincode",
+ "cap-std",
  "geo",
  "rstar",
  "rstest",

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ SPELLING_HELPER_PYTEST = PYTHONPATH=scripts $(SPELLING_PY_ENV) \
 	COVERAGE_FILE=$(SPELLING_COVERAGE_FILE) $(UV_ENV) $(UV) run --no-project \
 	--python 3.14 --with pathspec==$(PATHSPEC_VERSION) --with pytest==9.0.2 \
 	--with pytest-cov==7.0.0 python -m pytest
+WHITAKER ?= whitaker
 TEST_FLAGS ?=
 
 build: target/debug/$(APP) ## Build debug binary
@@ -49,8 +50,9 @@ bench: ## Run performance benchmarks
 target/%/$(APP): ## Build binary in debug or release mode
 	$(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin $(APP)
 
-lint: ## Run Clippy with warnings denied
+lint: ## Run Clippy and the Whitaker Dylint suite with warnings denied
 	$(CARGO) clippy $(CLIPPY_FLAGS)
+	RUSTFLAGS="-D warnings" $(WHITAKER) --all -- --all-targets --all-features
 
 typecheck: ## Typecheck the workspace
 	RUSTFLAGS="-D warnings" $(CARGO) check --workspace --all-targets --all-features $(BUILD_JOBS)

--- a/wildside-core/Cargo.toml
+++ b/wildside-core/Cargo.toml
@@ -12,6 +12,7 @@ thiserror = "1"
 serde = { version = "1", optional = true, features = ["derive"] }
 serde_json = { version = "1", optional = true }
 bincode = { version = "1", optional = true }
+cap-std = { workspace = true, optional = true }
 
 [dev-dependencies]
 # Parameterised tests rely on rstest macros.
@@ -23,7 +24,7 @@ tempfile = "3"
 [features]
 default = ["serde", "store-sqlite"]
 serde = ["dep:serde", "dep:serde_json", "geo/use-serde", "rstar/serde"]
-store-sqlite = ["serde", "dep:bincode", "dep:rusqlite"]
+store-sqlite = ["serde", "dep:bincode", "dep:cap-std", "dep:rusqlite"]
 test-support = []
 
 [package.metadata.docs.rs]

--- a/wildside-core/src/profile.rs
+++ b/wildside-core/src/profile.rs
@@ -79,9 +79,14 @@ impl InterestProfile {
     /// profile.set_weight(Theme::Shopping, 0.7);
     /// assert_eq!(profile.weight(&Theme::Shopping), Some(0.7));
     /// ```
+    #[track_caller]
     pub fn set_weight(&mut self, theme: Theme, weight: f32) {
-        self.try_set_weight(theme, weight)
-            .expect("weight must be finite and within 0.0..=1.0");
+        // Panic explicitly rather than via `expect`: this convenience
+        // wrapper documents its panic contract, and fallible callers should
+        // use `try_set_weight` to propagate the error instead.
+        if let Err(error) = self.try_set_weight(theme, weight) {
+            panic!("weight must be finite and within 0.0..=1.0: {error}");
+        }
     }
 
     /// Validate and set a theme weight.
@@ -122,6 +127,8 @@ impl InterestProfile {
 
 #[cfg(any(test, feature = "test-support"))]
 pub mod test_support {
+    //! Test-only extensions for [`InterestProfile`].
+
     use super::*;
 
     /// Test-only helpers for `InterestProfile`.

--- a/wildside-core/src/store/spatial_index.rs
+++ b/wildside-core/src/store/spatial_index.rs
@@ -4,12 +4,13 @@
 //! used by the SQLite-backed POI store.
 
 use std::{
-    fs::File,
-    io::{Read, Write},
+    ffi::OsStr,
+    io::{self, Read, Write},
     path::{Path, PathBuf},
 };
 
 use bincode::{deserialize_from, serialize_into};
+use cap_std::{ambient_authority, fs::Dir};
 use thiserror::Error;
 
 use crate::PointOfInterest;
@@ -94,15 +95,37 @@ pub fn write_spatial_index(
     write_index(path, entries)
 }
 
+/// Open the parent directory of `path` as a capability handle.
+///
+/// Ambient authority is confined to this single boundary; the rest of the
+/// module performs file I/O through the returned `Dir` handle, keeping the
+/// capability surface explicit.
+fn open_parent_dir(path: &Path) -> io::Result<(Dir, &OsStr)> {
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "path has no file name"))?;
+    let parent = match path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent,
+        _ => Path::new("."),
+    };
+    let dir = Dir::open_ambient_dir(parent, ambient_authority())?;
+    Ok((dir, file_name))
+}
 /// Persist a spatial index file without exposing the public wrapper signature.
 pub(crate) fn write_index(
     path: &Path,
     entries: &[PointOfInterest],
 ) -> Result<(), SpatialIndexWriteError> {
-    let mut file = File::create(path).map_err(|source| SpatialIndexWriteError::Io {
+    let (dir, file_name) = open_parent_dir(path).map_err(|source| SpatialIndexWriteError::Io {
         path: path.to_path_buf(),
         source,
     })?;
+    let mut file = dir
+        .create(file_name)
+        .map_err(|source| SpatialIndexWriteError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
 
     file.write_all(&SPATIAL_INDEX_MAGIC)
         .map_err(|source| SpatialIndexWriteError::Io {
@@ -127,10 +150,16 @@ pub(crate) fn write_index(
 
 /// Load POI entries from a spatial index artefact.
 pub(crate) fn load_index_entries(path: &Path) -> Result<Vec<PointOfInterest>, SpatialIndexError> {
-    let mut file = File::open(path).map_err(|source| SpatialIndexError::Io {
+    let (dir, file_name) = open_parent_dir(path).map_err(|source| SpatialIndexError::Io {
         path: path.to_path_buf(),
         source,
     })?;
+    let mut file = dir
+        .open(file_name)
+        .map_err(|source| SpatialIndexError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
 
     let mut magic = [0_u8; 4];
     file.read_exact(&mut magic)

--- a/wildside-solver-vrp/src/solver/mod.rs
+++ b/wildside-solver-vrp/src/solver/mod.rs
@@ -282,20 +282,21 @@ fn final_leg_duration(from_index: usize, end_index: usize, matrix: &[Vec<Duratio
         return Duration::ZERO;
     }
 
-    matrix
+    let Some(duration) = matrix
         .get(from_index)
         .and_then(|row| row.get(end_index))
         .copied()
-        .unwrap_or_else(|| {
-            log::warn!(
-                "Matrix access failed for final leg from index {from_index} to index {end_index}; falling back to zero duration"
-            );
-            debug_assert!(
-                false,
-                "Matrix access failed for final leg from index {from_index} to index {end_index}"
-            );
-            Duration::ZERO
-        })
+    else {
+        log::warn!(
+            "Matrix access failed for final leg from index {from_index} to index {end_index}; falling back to zero duration"
+        );
+        debug_assert!(
+            false,
+            "Matrix access failed for final leg from index {from_index} to index {end_index}"
+        );
+        return Duration::ZERO;
+    };
+    duration
 }
 
 fn route_duration(
@@ -309,13 +310,14 @@ fn route_duration(
     let poi_index = build_poi_index(all_pois);
     for poi in route_pois {
         let poi_id = poi.id;
-        let next_index = poi_index.get(&poi_id).copied().unwrap_or_else(|| {
+        let looked_up = poi_index.get(&poi_id).copied();
+        debug_assert!(looked_up.is_some(), "POI {poi_id} not found in index");
+        if looked_up.is_none() {
             log::warn!(
                 "POI {poi_id} not found in POI index; falling back to previous index {prev_index}"
             );
-            debug_assert!(false, "POI {poi_id} not found in index");
-            prev_index
-        });
+        }
+        let next_index = looked_up.unwrap_or(prev_index);
         if let Some(row) = matrix.get(prev_index)
             && let Some(edge) = row.get(next_index)
         {


### PR DESCRIPTION
## Summary

This change adopts the Whitaker Dylint suite as part of the estate-wide
rollout (reference adoption: leynos/netsuke#410). The `lint` Makefile
target now runs the suite after Clippy with warnings denied, and CI
installs the suite via `whitaker-installer` 0.2.5 before linting,
preferring `cargo binstall` with a build-from-source fallback and a
cache for the installer binary.

Findings reported by the suite are fixed in a separate commit:

- `no_std_fs_operations`: spatial index persistence now uses
  capability-based `cap_std` directory handles, confining ambient
  authority to a single boundary function.
- `no_expect_outside_tests`: `InterestProfile::set_weight` panics
  explicitly with the validation error rather than calling `expect`;
  fallible callers should prefer `try_set_weight`.
- `module_must_have_inner_docs`: the profile `test_support` module
  gains its inner doc comment.
- `no_unwrap_or_else_panic`: the VRP solver's panicking
  `unwrap_or_else` closures become explicit non-panicking fallbacks
  that retain the warning log and debug assertion.

No `dylint.toml` exclusions were required.

## Review walkthrough

- [Makefile](https://github.com/leynos/wildside-engine/blob/adopt-whitaker/Makefile):
  `WHITAKER` tool variable and the suite appended to the `lint` target.
- [.github/workflows/ci.yml](https://github.com/leynos/wildside-engine/blob/adopt-whitaker/.github/workflows/ci.yml):
  installer cache and hardened install step ahead of the lint step.
- [wildside-core/src/store/spatial_index.rs](https://github.com/leynos/wildside-engine/blob/adopt-whitaker/wildside-core/src/store/spatial_index.rs):
  cap_std-based persistence with `open_parent_dir` as the sole ambient
  boundary.
- [wildside-core/src/profile.rs](https://github.com/leynos/wildside-engine/blob/adopt-whitaker/wildside-core/src/profile.rs):
  explicit panic in `set_weight` and the documented test-support module.
- [wildside-solver-vrp/src/solver/mod.rs](https://github.com/leynos/wildside-engine/blob/adopt-whitaker/wildside-solver-vrp/src/solver/mod.rs):
  non-panicking fallbacks for matrix and index lookups.

## Validation

- `make check-fmt` — passed.
- `make lint` (Clippy plus the Whitaker suite, warnings denied) — passed.
- `make typecheck` — passed.
- `make test` — 342 tests run, 342 passed.
- `make markdownlint` — 23 files, 0 errors.
- `make test-workflow-contracts` — 6 passed.
- `make nixie` — all diagrams validated.
