### PR TITLE
Wire the CodeScene coverage gate into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,14 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN || '' }}
+      CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 || '' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
-      - uses: leynos/shared-actions/.github/actions/setup-rust@80935e57261986b39b958d7873435a50f14d592e
+        with:
+          fetch-depth: 0
+      - uses: leynos/shared-actions/.github/actions/setup-rust@29eea2635ee0f92e42c05f4cd360b7f1a2f00b12
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
       - name: Install cargo-nextest
         uses: taiki-e/install-action@848136c5ba4ea848a76ce75b8babe954359c4381
@@ -29,6 +34,28 @@ jobs:
         run: make lint
       - name: Test
         run: make test
+      - name: Generate coverage
+        # Coverage is only needed for the pull-request changed-line gate
+        # (deferred below); once coverage-main.yml exists, generating it
+        # again on the push-to-main trigger would be redundant.
+        if: github.event_name == 'pull_request'
+        uses: leynos/shared-actions/.github/actions/generate-coverage@29eea2635ee0f92e42c05f4cd360b7f1a2f00b12
+        with:
+          output-path: lcov.info
+          format: lcov
+          features: test-support
+          use-cargo-nextest: 'true'
+          with-ratchet: 'true'
+      # The `mode: check` step is deliberately not wired in yet: CodeScene
+      # project 70674 has no coverage-gates configuration, so
+      # `cs-coverage check` fails every run with "HTTP call succeeded,
+      # but the received project-config isn't valid. Lacks the gates
+      # configuration." — a CodeScene-side per-project setting, not a CI
+      # defect (ddlint and chutoro hit the byte-identical error). Add the
+      # check step in a fast-follow PR once coverage-main.yml has
+      # uploaded to main at least once and the gate is confirmed to
+      # resolve, or once CodeScene confirms the project's coverage gate
+      # is enabled.
       - name: Lint Markdown
         uses: DavidAnson/markdownlint-cli2-action@8de2aa07cae85fd17c0b35642db70cf5495f1d25 # v24.0.0
         with:
@@ -96,7 +123,7 @@ jobs:
       # Intentional duplication with the build job keeps the matrix
       # self-contained; refactor to a composite action if this grows.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
-      - uses: leynos/shared-actions/.github/actions/setup-rust@80935e57261986b39b958d7873435a50f14d592e
+      - uses: leynos/shared-actions/.github/actions/setup-rust@29eea2635ee0f92e42c05f4cd360b7f1a2f00b12
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
       - name: Install cargo-nextest
         uses: taiki-e/install-action@848136c5ba4ea848a76ce75b8babe954359c4381

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -1,0 +1,42 @@
+name: Coverage (main)
+
+# CodeScene accepts `cs-coverage upload` only for analysed branches, so
+# main-branch coverage is uploaded here on push; pull requests only
+# generate coverage in ci.yml (the changed-line gate is deferred — see
+# the comment there). This workflow also advances the coverage ratchet
+# baseline: caches saved on main are readable by every pull-request run,
+# so the baseline written here is the one PR ratchet checks compare
+# against.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  coverage-upload:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN || '' }}
+      CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 || '' }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
+      - name: Setup Rust
+        uses: leynos/shared-actions/.github/actions/setup-rust@29eea2635ee0f92e42c05f4cd360b7f1a2f00b12
+      - name: Generate coverage
+        uses: leynos/shared-actions/.github/actions/generate-coverage@29eea2635ee0f92e42c05f4cd360b7f1a2f00b12
+        with:
+          output-path: lcov.info
+          format: lcov
+          features: test-support
+          use-cargo-nextest: 'true'
+          with-ratchet: 'true'
+      - name: Upload coverage data to CodeScene
+        if: env.CS_ACCESS_TOKEN != ''
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@29eea2635ee0f92e42c05f4cd360b7f1a2f00b12
+        with:
+          format: lcov
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ env.CODESCENE_CLI_SHA256 }}

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC workflow-source resolution
-    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@2b09d10192627fd6e1034e7c12625dd266b45503
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@29eea2635ee0f92e42c05f4cd360b7f1a2f00b12
     with:
       # The workspace members live beside the root crate rather than
       # under crates/, so cover each member directory explicitly.

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -24,7 +24,7 @@ WORKFLOW_PATH = (
 
 #: The pinned commit of leynos/shared-actions (artefact preservation on
 #: timeout). Bump the workflow and this test together.
-PINNED_SHA = "2b09d10192627fd6e1034e7c12625dd266b45503"
+PINNED_SHA = "29eea2635ee0f92e42c05f4cd360b7f1a2f00b12"
 
 EXPECTED_USES = (
     "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA


### PR DESCRIPTION
## Summary

This onboards wildside-engine to the CodeScene coverage rollout,
following the estate recipe (proven on netsuke and
[mxd#362](https://github.com/leynos/mxd/pull/362)) and its revised
policy from the ddlint/chutoro findings.

**The changed-line gate (`mode: check`) is deliberately deferred.**
CodeScene project [70674](https://codescene.io/projects/70674) has no
coverage-gates configuration yet, so `cs-coverage check` would fail
every run with `received project-config isn't valid. Lacks the gates
configuration` — a CodeScene-side per-project setting that cannot be
enabled from CI (ddlint and chutoro hit the byte-identical error, and
ortho-config#377/#376 onboarded under the same deferred approach).
This PR therefore wires everything *except* the gate: the pin bump,
`fetch-depth: 0`, LCOV coverage generation, the ratchet, main-branch
upload, and secrets. A fast-follow PR will add the `mode: check` step
once `coverage-main.yml` has uploaded from main and the gate is
confirmed enabled CodeScene-side.

The only required check remains `build`; `feature-matrix` is not a
required check and is untouched by this change beyond the pin bump.

- Bump every `leynos/shared-actions` reference in the repository to
  `29eea2635ee0f92e42c05f4cd360b7f1a2f00b12`, a descendant of
  `927edd45ae77be4251a8a18ca9eb5613a2e32cbd` (shared-actions#334,
  which adds `mode: check` and fixes the two upload defects in
  shared-actions#333). This SHA is already in use in
  `dependabot-automerge.yml` and is the target of two open Dependabot
  PRs (#100, #102), so this single repo-wide pin lets those PRs
  auto-close instead of ping-ponging against a separate bump.
- Check out with `fetch-depth: 0` in the `build` job and generate LCOV
  coverage with the ratchet enabled, gated to `pull_request` events
  (the `build` job also runs on push to `main`, which
  `coverage-main.yml` now covers instead). Coverage uses
  `--features test-support` with default features, mirroring `make
  test`'s baseline and the mutation-testing caller's feature choice;
  `use-cargo-nextest: 'true'` matches the nextest already installed
  and used by `make test` in this job.
- Add
  [`coverage-main.yml`](https://github.com/leynos/wildside-engine/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml),
  modelled on mxd#362 and ddlint#287: on push to `main` it regenerates
  the same coverage and uploads it with the default `mode: upload`,
  and advances the ratchet baseline that PR runs compare against
  (caches saved on `main` are readable by every PR; caches saved by a
  PR run are scoped to that PR branch).
- Leave a comment in `ci.yml` where the `mode: check` step will go,
  describing the fast-follow.
- Update `tests/workflow_contracts/mutation_testing_test.py`'s pinned
  SHA alongside the `mutation-testing.yml` pin bump it checks.

`CS_ACCESS_TOKEN` has been set in both the Actions and Dependabot
secret stores.

## Review walkthrough

- [`.github/workflows/ci.yml`](https://github.com/leynos/wildside-engine/blob/codescene-coverage-gate/.github/workflows/ci.yml) —
  pin bump (both jobs), `fetch-depth: 0`, guarded coverage generation
  on the `build` job, deferred-gate comment.
- [`.github/workflows/coverage-main.yml`](https://github.com/leynos/wildside-engine/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml) —
  new push-to-main upload workflow.
- [`.github/workflows/mutation-testing.yml`](https://github.com/leynos/wildside-engine/blob/codescene-coverage-gate/.github/workflows/mutation-testing.yml) —
  pin bump only, no behavioural change (single repo-wide
  `shared-actions` pin; `dependabot-automerge.yml` was already at this
  SHA).
- [`tests/workflow_contracts/mutation_testing_test.py`](https://github.com/leynos/wildside-engine/blob/codescene-coverage-gate/tests/workflow_contracts/mutation_testing_test.py) —
  pinned-SHA contract updated alongside the workflow it checks.

Note for reviewers: the `CodeScene Code Health Review` check the
CodeScene GitHub App already posts on PRs is separate from coverage
and unaffected. No `CodeScene Code Coverage` check is expected to
appear on this PR's head, because the coverage gate is not enabled for
this project — this change only prepares the CI side so that switch is
safe to flip once CodeScene enables it.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open(...))"` for every
  workflow file under `.github/workflows/`.
- `make test-workflow-contracts` — 6 passed.
- `CS_ACCESS_TOKEN` confirmed set in both the Actions and Dependabot
  secret stores for `leynos/wildside-engine`.
- The repo's full build/lint/test suite was not run locally per the
  rollout's execution mechanics (shared, heavy machine); CI on this
  PR's own head is the validation surface for the new coverage step.

## Summary by Sourcery

Wire CodeScene coverage generation and upload into the CI pipelines for both pull requests and the main branch, standardizing shared-actions pins and setting up environment configuration while deferring the actual coverage gate check until the project is ready.

New Features:
- Add a dedicated coverage workflow on pushes to main that generates LCOV data and uploads CodeScene coverage while advancing the ratchet baseline.

Enhancements:
- Generate LCOV coverage for pull requests in the existing CI build job with ratcheting enabled, preparing for a future changed-line coverage gate.
- Propagate CodeScene access token and CLI checksum into CI jobs to support coverage upload tooling.
- Update all references to the shared-actions pin, including the mutation-testing workflow and its contract test, to a single newer commit SHA.

Build:
- Introduce coverage-main.yml to handle main-branch coverage generation and upload to CodeScene as part of the CI workflows.
- Adjust CI checkout configuration to use full history (fetch-depth: 0) required for CodeScene coverage tooling.

CI:
- Prepare but deliberately defer the CodeScene coverage gate check step in ci.yml, documenting the follow-up required once project-side gates are enabled.

Tests:
- Update the workflow contract test for mutation-testing to track the new shared-actions commit pin used by the workflow.