### PR TITLE
Relax mutation-testing contract test to a shape assertion

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -36,4 +36,40 @@ Local validation can use the same Make target:
 make nixie
 ```
 
+## Workflow pins and Dependabot
+
+Dependabot owns the upgrade of GitHub Actions and reusable workflows,
+including calls into `leynos/shared-actions`. Contract tests that assert a
+caller's exact commit SHA create a lockstep dependency: every time Dependabot
+opens a bump PR, the test fails until a human edits the pinned constant to
+match. That defeats the purpose of automated dependency updates and turns a
+routine bump into a manual chore.
+
+Contract tests may still verify the *shape* of a reusable-workflow caller.
+They must not verify the specific SHA value.
+
+- Do assert the workflow references the correct reusable workflow path.
+- Do assert the ref is pinned to a full 40-character commit SHA, not a
+  mutable branch such as `main` or `rolling`.
+- Do assert the expected `on:` triggers, least-privilege `permissions:`, and
+  the inputs the caller relies on.
+- Do not hard-code the current SHA value as an expected string. Match it with
+  a pattern instead.
+- Do not fail a test purely because Dependabot bumped the pinned SHA.
+
+```python
+import re
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def test_uses_pinned_full_sha(caller_step):
+    ref = caller_step["uses"].split("@")[-1]
+    assert SHA_RE.match(ref), f"expected a 40-hex commit SHA, got {ref!r}"
+```
+
+If a workflow's behaviour genuinely depends on a feature only present from a
+particular commit onwards, express that as a comment or a changelog note, not
+as a test assertion on the SHA string.
+
 [^1]: <https://github.com/leynos/shared-actions/tree/main/.github/actions/setup-rust>

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -3,17 +3,21 @@
 The executable logic lives in the ``leynos/shared-actions`` reusable
 workflow, which carries its own unit and integration tests;
 wildside-engine's caller is declarative configuration. These tests parse
-the caller with PyYAML and pin the contract it must uphold, so drift
-(repointing the pin at a branch, widening permissions, or losing the
-workspace paths, scaffolding excludes, or test-support feature args)
-fails CI on the pull request rather than surfacing in a scheduled or
-manual run.
+the caller with PyYAML and assert that it references the correct reusable
+workflow at a commit SHA, and that the other structural guards (triggers,
+permissions, and the ``with:`` inputs) hold, so drift (repointing the
+reference at a branch, widening permissions, or losing the workspace
+paths, scaffolding excludes, or test-support feature args) fails CI on
+the pull request rather than surfacing in a scheduled or manual run.
+Dependabot owns the pinned SHA value; these tests do not assert which
+commit is pinned.
 
 Run via ``make test-workflow-contracts``.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import yaml
@@ -22,12 +26,11 @@ WORKFLOW_PATH = (
     Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
 )
 
-#: The pinned commit of leynos/shared-actions (artefact preservation on
-#: timeout). Bump the workflow and this test together.
-PINNED_SHA = "29eea2635ee0f92e42c05f4cd360b7f1a2f00b12"
-
-EXPECTED_USES = (
-    "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
+#: Matches the reusable workflow path pinned to a full 40-hex commit SHA.
+#: The specific SHA value is Dependabot's to bump; this test only checks
+#: the shape.
+USES_RE = re.compile(
+    r"^leynos/shared-actions/\.github/workflows/mutation-cargo\.yml@[0-9a-f]{40}$"
 )
 
 #: The exact caller configuration: workspace member directories beside
@@ -68,25 +71,14 @@ def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
     return jobs["mutation"]
 
 
-def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
-    """The job must call the shared workflow at the exact documented SHA."""
+def test_uses_reference_is_pinned_to_a_commit_sha() -> None:
+    """The job must call the shared workflow pinned to a commit SHA."""
     uses = _mutation_job(_load()).get("uses")
     assert uses is not None, "jobs.mutation.uses is missing"
-    path, _, ref = uses.partition("@")
-    assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
-        f"jobs.mutation.uses must reference mutation-cargo.yml, got {path!r}"
-    )
-    assert len(ref) == 40, (
-        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert all(c in "0123456789abcdef" for c in ref), (
-        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert uses == EXPECTED_USES, (
-        f"jobs.mutation.uses pins {ref!r}; this test documents {PINNED_SHA!r} — "
-        "bump this test together with the workflow"
+    assert USES_RE.match(uses), (
+        f"jobs.mutation.uses must reference mutation-cargo.yml pinned to a "
+        f"full 40-character lowercase hex commit SHA, not a branch or tag: "
+        f"{uses!r}"
     )
 
 


### PR DESCRIPTION
## Summary

- Replace the mutation-testing contract test's exact-SHA equality assertion
  on `jobs.mutation.uses` with a regex that checks the reusable workflow
  path and a full 40-hex commit SHA, without pinning which SHA.
- Document the shape-only contract-test policy in the developers' guide.

## Review walkthrough

- `tests/workflow_contracts/mutation_testing_test.py`: dropped
  `PINNED_SHA`/`EXPECTED_USES` and the "bump the workflow and this test
  together" doc-comment. `test_uses_reference_is_pinned_to_the_documented_sha`
  became `test_uses_reference_is_pinned_to_a_commit_sha`, matching
  `uses` against
  `^leynos/shared-actions/\.github/workflows/mutation-cargo\.yml@[0-9a-f]{40}$`.
  The module docstring no longer claims the test pins the SHA. All other
  tests (permissions, workflow-level permissions, concurrency, triggers,
  the `with:` block) are unchanged.
- `docs/developers-guide.md`: new "Workflow pins and Dependabot" section
  explaining that Dependabot owns the SHA, contract tests must only check
  shape, and giving a short example.

This hands ownership of the pinned `leynos/shared-actions` commit SHA to
Dependabot: bump PRs will no longer fail CI purely because the test's
hard-coded constant is stale, while the test still catches repointing at a
mutable branch/tag, permission widening, or loss of the workspace paths,
scaffolding excludes, or test-support feature args.

## Validation

- `make test-workflow-contracts` passes locally against the currently
  pinned SHA (`29eea2635ee0f92e42c05f4cd360b7f1a2f00b12`).
- Reasoned the regex also accepts any other well-formed 40-hex SHA (e.g. a
  future Dependabot bump) and rejects a branch/tag ref such as `@main`.
- `.github/dependabot.yml` already has a `github-actions` ecosystem entry
  with `directory: "/"` and a weekly schedule, so no change was needed
  there.
