### PR TITLE
Wire the CodeScene mode: check coverage gate into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,16 +46,17 @@ jobs:
           features: test-support
           use-cargo-nextest: 'true'
           with-ratchet: 'true'
-      # The `mode: check` step is deliberately not wired in yet: CodeScene
-      # project 70674 has no coverage-gates configuration, so
-      # `cs-coverage check` fails every run with "HTTP call succeeded,
-      # but the received project-config isn't valid. Lacks the gates
-      # configuration." — a CodeScene-side per-project setting, not a CI
-      # defect (ddlint and chutoro hit the byte-identical error). Add the
-      # check step in a fast-follow PR once coverage-main.yml has
-      # uploaded to main at least once and the gate is confirmed to
-      # resolve, or once CodeScene confirms the project's coverage gate
-      # is enabled.
+      - name: Check coverage against CodeScene gates
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: env.CS_ACCESS_TOKEN != '' && github.event_name == 'pull_request'
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@29eea2635ee0f92e42c05f4cd360b7f1a2f00b12
+        with:
+          format: lcov
+          mode: check
+          project-url: https://api.codescene.io/v2/projects/70674
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}
       - name: Lint Markdown
         uses: DavidAnson/markdownlint-cli2-action@8de2aa07cae85fd17c0b35642db70cf5495f1d25 # v24.0.0
         with:

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -1,12 +1,11 @@
 name: Coverage (main)
 
 # CodeScene accepts `cs-coverage upload` only for analysed branches, so
-# main-branch coverage is uploaded here on push; pull requests only
-# generate coverage in ci.yml (the changed-line gate is deferred — see
-# the comment there). This workflow also advances the coverage ratchet
-# baseline: caches saved on main are readable by every pull-request run,
-# so the baseline written here is the one PR ratchet checks compare
-# against.
+# main-branch coverage is uploaded here on push; pull requests generate
+# coverage and run the changed-line `mode: check` gate in ci.yml. This
+# workflow also advances the coverage ratchet baseline: caches saved on
+# main are readable by every pull-request run, so the baseline written
+# here is the one PR ratchet checks compare against.
 
 on:
   push:


### PR DESCRIPTION
## Summary

- CodeScene project 70674's coverage-gates configuration is now
  enabled, so the deferred `mode: check` step can run instead of
  failing with "Lacks the gates configuration".
- Replace the deferred-gate comment in `ci.yml` with the guarded
  `Check coverage against CodeScene gates` step, using the same
  `format: lcov` and shared-actions pin
  (`29eea2635ee0f92e42c05f4cd360b7f1a2f00b12`) already used by
  `generate-coverage`.
- Refresh the stale cross-reference in `coverage-main.yml`'s header
  comment, which previously described the gate as deferred.

## Review walkthrough

- [.github/workflows/ci.yml](https://github.com/leynos/wildside-engine/blob/codescene-mode-check/.github/workflows/ci.yml):
  the new step runs only on pull requests with `CS_ACCESS_TOKEN` set,
  after coverage generation, targeting
  `https://api.codescene.io/v2/projects/70674`.
- [.github/workflows/coverage-main.yml](https://github.com/leynos/wildside-engine/blob/codescene-mode-check/.github/workflows/coverage-main.yml):
  comment-only change; the `mode: upload` step is untouched.

## Validation

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on both workflow
  files.
- [x] `make test-workflow-contracts` (6 passed).
- [ ] CI green on this PR's own head, with the "Check coverage against
  CodeScene gates" step executing (not skipped) and succeeding, and
  the `CodeScene Code Coverage` check completing.
