### PR TITLE
Document mutation-testing workflow contract tests

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -95,4 +95,69 @@ If a workflow's behaviour genuinely depends on a feature only present from a
 particular commit onwards, express that as a comment or a changelog note, not
 as a test assertion on the SHA string.
 
+## Mutation-testing workflow contract tests
+
+This repository runs scheduled, informational mutation testing through a thin
+caller workflow, [`.github/workflows/mutation-testing.yml`](../.github/workflows/mutation-testing.yml),
+which delegates to the shared reusable workflow
+`leynos/shared-actions/.github/workflows/mutation-cargo.yml`. The heavy lifting
+— running `cargo-mutants`, sharding, and summarizing survivors — lives in
+`shared-actions`; this repository carries only declarative configuration. The
+run is **informational only**: it never gates a pull request. Survivors are
+reported through the job summary and downloadable artefacts so they can be
+triaged into tests, not enforced as a blocking check.
+
+The workflow runs in two modes. A **daily schedule** fires a change-scoped run
+that mutates only the source files touched within the detection window, so
+quiet days are cheap no-ops. A **manual dispatch** (the Actions "Run workflow"
+control) mutates the whole workspace, fanned out across shards; select a
+branch in that control to exercise a feature branch.
+
+The caller passes a small set of configuration inputs, each carrying intent:
+
+- `paths` — the change-detection globs that decide whether a scheduled run has
+  anything to mutate. Because the workspace members (`wildside-cli`,
+  `wildside-core`, `wildside-data`, `wildside-fs`, `wildside-scorer`,
+  `wildside-solver-ortools`, `wildside-solver-vrp`) live beside the root crate
+  rather than under a shared `crates/` directory, each member directory is
+  listed explicitly alongside `src/`.
+- `exclude-globs` — feature-gated test-support and benchmark scaffolding
+  (`test_support.rs`, `bench_support.rs`) whose surviving mutants are noise
+  rather than genuine test gaps, kept out of the survivors table.
+- `extra-args` — arguments forwarded to `cargo-mutants` (here
+  `--features test-support --test-workspace=true`) so the mutation run
+  matches the CI baseline. `--features test-support` matches `make test`,
+  which compiles the shared test-double scaffolding; `--test-workspace=true`
+  runs the whole workspace's test suite against each mutant rather than only
+  the mutated package's own tests, so crates that are covered indirectly by a
+  dependent crate's tests do not report false survivors.
+
+The `uses:` reference pins the shared workflow to a full 40-character commit
+SHA rather than a branch or tag, so a force-push upstream cannot silently
+change what runs here. The contract test asserts only that the pin is a full
+commit SHA, not a particular value, so Dependabot bumps it automatically
+without any accompanying test edit. The `with:` block is checked differently:
+it is compared for exact equality against a hard-coded expected mapping, so
+adding, removing, or editing any input requires updating the test alongside
+the workflow in the same change.
+
+Because the caller is configuration rather than code, a contract test pins
+the shape it must uphold, failing the pull request when the caller drifts —
+repointing the pin at a branch, widening the token scope, or dropping a
+configuration input — rather than letting the breakage surface only in a
+scheduled run. Run it locally with `make test-workflow-contracts`. The test,
+[`tests/workflow_contracts/mutation_testing_test.py`](../tests/workflow_contracts/mutation_testing_test.py),
+validates:
+
+- the `uses:` reference targets `mutation-cargo.yml` pinned to a full commit
+  SHA;
+- job permissions are exactly `contents: read` and `id-token: write`, and the
+  workflow-level default token scope is empty;
+- `concurrency` serializes runs per ref (`mutation-testing-${{ github.ref }}`)
+  without cancelling one in progress;
+- the triggers keep the daily 04:20 UTC schedule and a plain
+  `workflow_dispatch` with no legacy branch input; and
+- the `with:` block carries exactly the expected `paths`, `exclude-globs`,
+  and `extra-args` values described above.
+
 [^1]: <https://github.com/leynos/shared-actions/tree/main/.github/actions/setup-rust>


### PR DESCRIPTION
## Summary

Adds a "Mutation-testing workflow contract tests" section to
[`docs/developers-guide.md`](docs/developers-guide.md), documenting the
contract tests in
[`tests/workflow_contracts/mutation_testing_test.py`](tests/workflow_contracts/mutation_testing_test.py)
that guard `.github/workflows/mutation-testing.yml`, the thin caller of
`leynos/shared-actions/.github/workflows/mutation-cargo.yml` (Rust
workspace permutation).

Reconciled against the real files, not assumed:

- **`uses:` pin style**: shape-only. `USES_RE` asserts the reference is
  `mutation-cargo.yml` pinned to a full 40-hex commit SHA, without
  asserting a specific SHA value, so Dependabot bumps it freely.
- **`with:` block**: hard equality. `EXPECTED_WITH` is asserted equal to
  the caller's `with:` mapping, so changing any input (`paths`,
  `exclude-globs`, `extra-args`) requires updating the workflow and the
  test constant together.
- **Workspace permutation**: `extra-args` carries
  `--features test-support --test-workspace=true`; the section explains
  both flags (matching the CI `make test` baseline, and running the
  whole workspace's tests against each mutant so crates covered only via
  a dependent crate's tests do not report false survivors).
- **Local command**: `make test-workflow-contracts` (defined in the
  `Makefile`), which runs
  `uv run --with 'pytest>=8' --with 'pyyaml>=6' pytest tests/workflow_contracts -q`.

Placement: added as a new top-level `##` section at the end of the guide,
after the existing "Workflow pins and Dependabot" section (which covers
the general Dependabot-friendly SHA-pinning *policy*, not the
mutation-testing workflow specifically, so the new material is not a
duplicate).

TOC: `docs/developers-guide.md` has no table of contents or index list to
cross-link — the guide is a flat sequence of `##` sections, so nothing
further was added.

Roadmap/execplan: no roadmap or execplan tracking applies — `docs/roadmap.md`
and `docs/execplans/` contain no mutation-testing or workflow-contract-test
items to tick or annotate.

## Docs lint

`make markdownlint` (spelling + markdownlint-cli2) passes: 0 errors across
23 files, spelling gate clean after correcting two `-ise` spellings to the
repository's `-ize` en-GB-oxendict convention (`summarising` →
`summarizing`, `serialises` → `serializes`).

## Test plan

- [x] `make markdownlint` passes
- [ ] No code/behavioural tests run (docs-only change, per brief)
